### PR TITLE
Update yield comment to be accurate

### DIFF
--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -130,7 +130,7 @@ public interface RobotController {
      * Ends the current round.  If your player used fewer than
 	 * BYTECODE_LIMIT_BASE bytecodes this round, then it will
 	 * receive a flux bonus of
-     * <code>GameConstants.YIELD_BONUS * chassis.upkeep * (bytecodes_used) / BYTECODE_LIMIT_BASE</code>.
+     * <code>GameConstants.YIELD_BONUS * chassis.upkeep * (GameConstants.BYTECODE_LIMIT_BASE - (bytecodes_used)) / GameConstants.BYTECODE_LIMIT_BASE</code>.
      * Never fails.
      */
     public void yield();


### PR DESCRIPTION
The comment for the yield method incorrectly explained the calculation used to determine bonus flux gained from yielding. I have corrected the comment to match the calculation.
