### PR TITLE
Set cow growth to zero on VOID squares

### DIFF
--- a/src/main/battlecode/world/NeutralsMap.java
+++ b/src/main/battlecode/world/NeutralsMap.java
@@ -80,6 +80,9 @@ public class NeutralsMap {
             for (int j = 0; j < this.mapHeight; j++) {
                 passable[i][j] = mapTiles[i][j] != TerrainTile.VOID;
                 pastrID[i][j] = Integer.MAX_VALUE;
+                if (!passable[i][j]) {
+                    this.growthFactor[i][j] = 0;
+                }
             }
         }
         ids = new Set[this.mapWidth][this.mapHeight];


### PR DESCRIPTION
Right now, there are some maps that contain VOID squares with non-zero
cow growth, such as siege.xml, even though cows do not grow on VOID
squares.  These maps cause RobotController.senseCowGrowth() to return
an array that contains nonzero entries in those squares, even though
the actual cow growth in those squares is zero.

This commit fixes the bug.
