### PR TITLE
Fixed bug from debug mode (lol)

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -552,8 +552,8 @@ public class GameWorld extends BaseWorld<InternalObject> implements GenericWorld
         signals.add(new ShieldChangeSignal(shieldChangedRobots.toArray(new InternalRobot[]{})));
 
         if (includeBytecodesUsedSignal) {
-            	signals.add(new BytecodesUsedSignal(allRobots.toArray(new InternalRobot[]{})));
-		signals.add(new ActionDelaySignal(allRobots.toArray(new InternalRobot[]{})));
+        	signals.add(new BytecodesUsedSignal(allRobots.toArray(new InternalRobot[]{})));
+        	signals.add(new ActionDelaySignal(allRobots.toArray(new InternalRobot[]{})));
         }
 
         return signals.toArray(new Signal[signals.size()]);


### PR DESCRIPTION
More about this bug here: http://www.battlecode.org/contestants/forum/1/87/

It caused NullPointerException, because allRobots list was null (includeBytecodesUsedSignal argument had "false" value when called by user interaction in debug mode), and there was missing null check on line 557.
