### PR TITLE
Preliminary Java 7/8 Support (ASM 5.x update)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -11,8 +11,8 @@
     <dependency org="commons-cli" name="commons-cli" rev="1.2" />
     <dependency org="commons-io" name="commons-io" rev="2.4" />
     <dependency org="com.google.guava" name="guava" rev="r07"/>
-    <dependency org="asm" name="asm" rev="3.2" />
-    <dependency org="asm" name="asm-tree" rev="3.2" />
+    <dependency org="org.ow2.asm" name="asm" rev="5.0.3" />
+    <dependency org="org.ow2.asm" name="asm-tree" rev="5.0.3" />
     <!-- ivy thinks xstream depends on 6 different xml parsers and 3 optional packages but we only need xpp3 -->
     <dependency org="com.thoughtworks.xstream" name="xstream" rev="1.4.6" transitive="false"/>
     <dependency org="xmlpull" name="xmlpull" rev="1.1.3.1"/>

--- a/src/main/battlecode/engine/instrumenter/InterfaceReader.java
+++ b/src/main/battlecode/engine/instrumenter/InterfaceReader.java
@@ -15,16 +15,17 @@ import static org.objectweb.asm.ClassReader.SKIP_DEBUG;
  *
  * @author adamd
  */
-class InterfaceReader implements ClassVisitor {
+class InterfaceReader extends ClassVisitor {
 
     // this will store the final result of which interfaces are transitively implemented
     private String[] interfaces = null;
 
     public InterfaceReader() {
-        super();
+        super(Opcodes.ASM5);
     }
 
     public InterfaceReader(String className) {
+        super(Opcodes.ASM5);
         ClassReader cr;
         try {
             cr = new ClassReader(className);

--- a/src/main/battlecode/engine/instrumenter/RoboAdapter.java
+++ b/src/main/battlecode/engine/instrumenter/RoboAdapter.java
@@ -7,7 +7,7 @@ import org.objectweb.asm.*;
  *
  * @author adamd
  */
-public class RoboAdapter extends ClassAdapter implements Opcodes {
+public class RoboAdapter extends ClassVisitor implements Opcodes {
     private String className;
     private final String teamPackageName;
     private final boolean debugMethodsEnabled;
@@ -27,7 +27,7 @@ public class RoboAdapter extends ClassAdapter implements Opcodes {
      * @param silenced            whether System.out should be silenced for this class
      */
     public RoboAdapter(final ClassVisitor cv, final String teamPackageName, final boolean debugMethodsEnabled, boolean silenced, boolean checkDisallowed) {
-        super(cv);
+        super(Opcodes.ASM5, cv);
         this.teamPackageName = teamPackageName;
         this.debugMethodsEnabled = debugMethodsEnabled;
         this.silenced = silenced;


### PR DESCRIPTION
This bumps asm 3.2 all the way up to 5.0.3, giving us support for Java 7 & 8.

Pretty big change, so make sure to test thoroughly, esp wrt the bytecode counting system.  Note that there is code specifically to prevent `invokedynamic` instructions from going through because I haven't had enough time to understand instrumentation of the bootstrap methods. Shouldn't affect most contestants though as it's impossible to generate said instruction from Java.

So far it seems to be working, and it solves a ton of headaches for people when initially setting up Battlecode.
