### PR TITLE
Fix for constant pool illegal type during hashcode invokeinterface

### DIFF
--- a/src/main/battlecode/engine/instrumenter/RoboMethodTree.java
+++ b/src/main/battlecode/engine/instrumenter/RoboMethodTree.java
@@ -236,7 +236,7 @@ public class RoboMethodTree extends MethodNode implements Opcodes {
             // send the object, its hash code, and the hash code method owner to
             // ObjectHashCode for analysis
             instructions.insertBefore(n, new InsnNode(DUP));
-            instructions.insertBefore(n, new MethodInsnNode(n.getOpcode(), classReference(n.owner), "hashCode", "()I", false));
+            instructions.insertBefore(n, new MethodInsnNode(n.getOpcode(), classReference(n.owner), "hashCode", "()I", n.itf));
             instructions.insertBefore(n, new InsnNode(SWAP));
             if (n.getOpcode() == INVOKESPECIAL) {
                 instructions.insertBefore(n, new LdcInsnNode(Type.getObjectType(n.owner)));


### PR DESCRIPTION
most of java's stdlib uses the hashcode implementation on the interface, so we can't just blindly put "false" into the instrumentation