### PR TITLE
fix unhelpful error message

### DIFF
--- a/src/main/battlecode/engine/instrumenter/ClassReferenceUtil.java
+++ b/src/main/battlecode/engine/instrumenter/ClassReferenceUtil.java
@@ -38,7 +38,7 @@ public class ClassReferenceUtil {
     }
 
     static void fileLoadError(String filename) {
-        ErrorReporter.report(String.format("Error loading %s", "Check that the '%s' file exists and is not corrupted.", filename, filename));
+        ErrorReporter.report(String.format("Error loading %s",filename),String.format("Check that the '%s' file exists and is not corrupted.",filename));
         throw new InstrumentationException();
     }
 


### PR DESCRIPTION
This patch replaces the unhelpful error message described in the posts
http://www.battlecode.org/contestants/forum/1/145/
http://www.battlecode.org/contestants/forum/1/150/
with one that lists the file that the game is trying to find.