### PR TITLE
Separate GameMap, GameWorld, and XMLMapHandler somewhat

### DIFF
--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -3,6 +3,7 @@ package battlecode.common;
 /**
  * Defines constants that affect gameplay.
  */
+@SuppressWarnings("unused")
 public interface GameConstants {
 
     // *********************************
@@ -188,4 +189,10 @@ public interface GameConstants {
 
     /** Attack delay incurred by using the 'heavy hands' skill. **/
     double HEAVY_HANDS_ATTACK_DELAY = 3.0;
+
+    /** The default game seed. **/
+    int GAME_DEFAULT_SEED = 6370;
+
+    /** The default game maxiumum number of rounds. **/
+    int GAME_DEFAULT_ROUNDS = 2000;
 }

--- a/src/main/battlecode/engine/Engine.java
+++ b/src/main/battlecode/engine/Engine.java
@@ -28,26 +28,21 @@ public class Engine {
         this.garbageCollectEnabled = options.getBoolean("bc.engine.gc");
         this.garbageCollectRounds = options.getInt("bc.engine.gc-rounds");
         this.breakpointsEnabled = options.getBoolean("bc.engine.breakpoints");
-        GameWorld tempGameWorld = null;
-        //InternalRobot.resetIDs();
         IndividualClassLoader.reset();
         Scheduler.reset();
         RobotMonitor.reset();
         PlayerFactory.checkOptions();
+
         try {
-            try {
-                tempGameWorld = GameWorldFactory.createGameWorld(teamA, teamB, mapName, mapPath, teamMemory);
-            } catch (IllegalArgumentException e) {
-                java.lang.System.out.println("[Engine] Error while loading map '" + mapName + "'");
-                return;
-            } catch (Exception e) {
-                ErrorReporter.report(e);
-                return;
-            }
-        } finally {
-            gameWorld = tempGameWorld;
+            gameWorld = GameWorldFactory.createGameWorld(teamA, teamB, mapName, mapPath, teamMemory);
+        } catch (IllegalArgumentException e) {
+            System.out.println("[Engine] Error while loading map '" + mapName + "'");
+            throw e;
+        } catch (Exception e) {
+            ErrorReporter.report(e);
+            throw e;
         }
-        gameWorld.resetStatic();
+
         RobotMonitor.setGameWorld(gameWorld);
         RoboRandom.setMapSeed(gameWorld.getMapSeed());
         Scheduler.start();

--- a/src/main/battlecode/engine/PlayerFactory.java
+++ b/src/main/battlecode/engine/PlayerFactory.java
@@ -23,10 +23,6 @@ public class PlayerFactory {
     }
 
     public static void loadPlayer(RobotControllerImpl rc, String teamName) {
-        if (Config.getGlobalConfig().getBoolean("bc.engine.unit-test-mode")) {
-            return;
-        }
-
         // now, we instantiate and instrument the player's class
         Class playerClass;
         try {
@@ -51,10 +47,6 @@ public class PlayerFactory {
     }
     
     public static void loadZombiePlayer(RobotControllerImpl rc) {
-        if (Config.getGlobalConfig().getBoolean("bc.engine.unit-test-mode")) {
-            return;
-        }
-
         // instantiate and instrument the ZombiePlayer class
         Class playerClass;
         try {

--- a/src/main/battlecode/server/Config.java
+++ b/src/main/battlecode/server/Config.java
@@ -53,7 +53,6 @@ public class Config {
         defaults.setProperty("bc.engine.bytecodes-used", "true");
         defaults.setProperty("bc.engine.lazy-instrumenter", "false");
         defaults.setProperty("bc.engine.fast-hash", "false");
-        defaults.setProperty("bc.engine.unit-test-mode", "false");
 
         defaults.setProperty("bc.client.opengl", "false");
         defaults.setProperty("bc.client.use-models", "true");

--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -114,6 +114,18 @@ public class GameWorld implements SignalHandler {
         adjustResources(Team.B, GameConstants.PARTS_INITIAL_AMOUNT);
 
         removingDead = false;
+
+        reserveRandomIDs(32000);
+
+        // Add the robots contained in the GameMap to this world.
+        for (GameMap.InitialRobotInfo initialRobot : gameMap.getInitialRobots()) {
+            GameWorldFactory.createPlayer(
+                    this,
+                    initialRobot.type,
+                    initialRobot.getLocation(gameMap.getMapOrigin()),
+                    initialRobot.team,
+                    null, false, 0);
+        }
     }
 
     // *********************************
@@ -412,9 +424,6 @@ public class GameWorld implements SignalHandler {
             r.setBytecodesUsed(RobotMonitor.getBytecodesUsed());
             r.processEndOfTurn();
         }
-    }
-
-    public void resetStatic() {
     }
 
     public void notifyDied(InternalRobot r) {

--- a/src/main/battlecode/world/GameWorldFactory.java
+++ b/src/main/battlecode/world/GameWorldFactory.java
@@ -6,12 +6,6 @@ import battlecode.common.Team;
 import battlecode.engine.PlayerFactory;
 import battlecode.world.signal.SpawnSignal;
 
-/*
- TODO:
- - make the parser more robust, and with better failure modes
- - maybe take out the locations, objects, and terrain nodes
- - comments & javadoc
- */
 public class GameWorldFactory {
 
     public static GameWorld createGameWorld(String teamA, String teamB,
@@ -19,7 +13,7 @@ public class GameWorldFactory {
             throws IllegalArgumentException {
         XMLMapHandler handler = XMLMapHandler.loadMap(mapName, mapPath);
 
-        return handler.createGameWorld(teamA, teamB, teamMemory);
+        return new GameWorld(handler.getParsedMap(), teamA, teamB, teamMemory);
     }
 
     public static InternalRobot createPlayer(GameWorld gw, RobotType type,

--- a/src/test/battlecode/server/SerializerFactoryTestBase.java
+++ b/src/test/battlecode/server/SerializerFactoryTestBase.java
@@ -20,8 +20,7 @@ import battlecode.world.signal.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by james on 7/28/15.
@@ -53,16 +52,22 @@ public abstract class SerializerFactoryTestBase {
             new int[] {6, 7, 8},
     };
 
-    static final GameMap gameMap = new GameMap(properties, rubble, parts, zSchedule, "Test Map");
+    static final Set<GameMap.InitialRobotInfo> initialRobots = new HashSet<>();
+    static {
+        initialRobots.add(new GameMap.InitialRobotInfo(10, 100, RobotType.ARCHON, Team.B));
+    }
+
+    static final GameMap gameMap = new GameMap(properties,
+            rubble,
+            parts,
+            zSchedule,
+            initialRobots,
+            "Test Map");
 
     static final long[][] teamMemories = new long[][] {
             new long[] {1, 2, 3, 4, 5},
             new long[] {1, 2, 3, 4, 5},
     };
-
-    static final GameWorld gameWorld = new GameWorld(gameMap, "Team 1", "Team 2", teamMemories);
-
-    static final InternalRobot robot = new InternalRobot(gameWorld, RobotType.ARCHON, new MapLocation(0,0), Team.A, false, 0);
 
     // An array with a sample object from every type of thing we could ever want to serialize / deserialize.
     static final Object[] serializeableObjects = new Object[]{
@@ -73,24 +78,24 @@ public abstract class SerializerFactoryTestBase {
             new MatchInfo("Team 1", "Team 2", new String[] {"Map 1", "Map 2"}),
             new MatchHeader(gameMap, teamMemories, 0, 3),
             new RoundDelta(new Signal[] {
-                    new AttackSignal(robot.getID(), new MapLocation(1,1)),
-                    new BashSignal(robot.getID(), new MapLocation(1,1)),
-                    new BroadcastSignal(robot.getID(), robot.getTeam(), new HashMap<>()),
+                    new AttackSignal(57, new MapLocation(1,1)),
+                    new BashSignal(57, new MapLocation(1,1)),
+                    new BroadcastSignal(57, Team.B, new HashMap<>()),
                     new BuildSignal(57, new MapLocation(1,1), RobotType.GUARD, Team.A, 50),
-                    new BytecodesUsedSignal(new InternalRobot[]{robot}),
-                    new CastSignal(robot.getID(), new MapLocation(-75, -75)),
+                    new BytecodesUsedSignal(new int[] {5, 6}, new int[] {17, 32}),
+                    new CastSignal(57, new MapLocation(-75, -75)),
                     new ControlBitsSignal(0, 0),
-                    new DeathSignal(robot.getID()),
-                    new HealthChangeSignal(new InternalRobot[]{robot}),
-                    new IndicatorDotSignal(robot.getID(), robot.getTeam(), new MapLocation(0,0), 0, 0, 0),
-                    new IndicatorLineSignal(robot.getID(), robot.getTeam(), new MapLocation(0,0), new MapLocation(1,1), 0, 0, 0),
-                    new IndicatorStringSignal(robot.getID(), 0, "Test Indicator String"),
+                    new DeathSignal(57),
+                    new HealthChangeSignal(new int[] {5, 6}, new double[] {17.21, 32}),
+                    new IndicatorDotSignal(57, Team.B, new MapLocation(0,0), 0, 0, 0),
+                    new IndicatorLineSignal(57, Team.B, new MapLocation(0,0), new MapLocation(1,1), 0, 0, 0),
+                    new IndicatorStringSignal(57, 0, "Test Indicator String"),
                     new LocationOreChangeSignal(new MapLocation(0,0), -1.0),
-                    new MatchObservationSignal(robot.getID(), "test"),
+                    new MatchObservationSignal(57, "test"),
                     new MovementOverrideSignal(0, new MapLocation(10000, 10000)),
-                    new MovementSignal(robot.getID(), new MapLocation(0, 0), true, 0),
-                    new RobotDelaySignal(new InternalRobot[] {robot}),
-                    new SpawnSignal(robot, robot, 1000),
+                    new MovementSignal(57, new MapLocation(0, 0), true, 0),
+                    new RobotDelaySignal(new int[] {5, 6}, new double[] {17, 32}, new double[] {10, 2.5}),
+                    new SpawnSignal(120, 0, new MapLocation(5, 6), RobotType.ZOMBIEDEN, Team.ZOMBIE, 0),
                     new TeamOreSignal(Team.A, 100),
                     new XPSignal(0, 1000)
             }),

--- a/src/test/battlecode/world/TestMapGenerator.java
+++ b/src/test/battlecode/world/TestMapGenerator.java
@@ -1,18 +1,13 @@
 package battlecode.world;
 
-import battlecode.common.MapLocation;
-import battlecode.common.RobotType;
-import battlecode.common.Team;
-import battlecode.common.ZombieCount;
+import battlecode.common.*;
 import org.junit.Ignore;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.StringTokenizer;
+import java.util.*;
 
 /**
  * A class that creates instances of GameMap, mostly to be used for testing
@@ -107,7 +102,7 @@ public class TestMapGenerator {
     /** The map's zombie spawn schedule. Defaults to no zombies. */
     private ZombieSpawnSchedule zSchedule;
     /** All the robots on the map. Defaults to none. */
-    private ArrayList<RobotInfo> robots;
+    private Set<GameMap.InitialRobotInfo> robots;
 
     /**
      * Prepares an empty map of the given size. There will be no parts or rubble.
@@ -119,12 +114,12 @@ public class TestMapGenerator {
     public TestMapGenerator(int width, int height, int rounds) {
         this.width = width;
         this.height = height;
-        this.seed = GameMap.GAME_DEFAULT_SEED;
+        this.seed = GameConstants.GAME_DEFAULT_SEED;
         this.rounds = rounds;
         this.rubble = new int[width][height];
         this.parts = new int[width][height];
         this.zSchedule = new ZombieSpawnSchedule();
-        this.robots = new ArrayList<>();
+        this.robots = new HashSet<>();
     }
 
     /**
@@ -148,7 +143,7 @@ public class TestMapGenerator {
             }
         }
 
-        this.seed = GameMap.GAME_DEFAULT_SEED;
+        this.seed = GameConstants.GAME_DEFAULT_SEED;
         this.rounds = rounds;
         this.parts = new int[width][height];
         this.rubble = new int[width][height];
@@ -163,7 +158,7 @@ public class TestMapGenerator {
         }
 
         this.zSchedule = new ZombieSpawnSchedule();
-        this.robots = new ArrayList<>();
+        this.robots = new HashSet<>();
     }
 
     /**
@@ -268,7 +263,7 @@ public class TestMapGenerator {
      * @return itself, after the robot has been added
      */
     public TestMapGenerator withRobot(RobotType type, Team team, int x, int y) {
-        this.robots.add(new RobotInfo(type, team, new MapLocation(x, y)));
+        this.robots.add(new GameMap.InitialRobotInfo(x, y, type, team));
         return this;
     }
 
@@ -281,7 +276,7 @@ public class TestMapGenerator {
      * @param y y location for the robot
      */
     public void addRobot(RobotType type, Team team, int x, int y) {
-        this.robots.add(new RobotInfo(type, team, new MapLocation(x, y)));
+        this.robots.add(new GameMap.InitialRobotInfo(x, y, type, team));
     }
 
     /**
@@ -294,7 +289,7 @@ public class TestMapGenerator {
         EnumMap<GameMap.MapProperties, Integer> props = new EnumMap<>(GameMap.MapProperties.class);
         props.put(GameMap.MapProperties.ROUNDS, this.rounds);
         props.put(GameMap.MapProperties.SEED, this.seed);
-        return new GameMap(props, rubble, parts, zSchedule, mapName);
+        return new GameMap(props, rubble, parts, zSchedule, robots, mapName);
     }
 
     /**
@@ -344,10 +339,11 @@ public class TestMapGenerator {
                 else characters[j][i] = "r";
             }
         }
-        for (RobotInfo robot : robots) {
-            characters[robot.location.x][robot.location.y] = getSymbol(robot
+        for (GameMap.InitialRobotInfo robot : robots) {
+            characters[robot.originOffsetX][robot.originOffsetY] = getSymbol(robot
                     .type, robot.team);
         }
+
         for (int i = 0; i < height; ++i) {
             for (int j = 0; j < width; ++j) {
                 out.printf("%s", characters[j][i]);

--- a/src/test/battlecode/world/XMLMapHandlerTest.java
+++ b/src/test/battlecode/world/XMLMapHandlerTest.java
@@ -20,20 +20,11 @@ public class XMLMapHandlerTest {
      * @param mapName name of the map.
      * @return a GameWorld with this map.
      */
-    public GameWorld getMap(long[][] teamMemory, String mapName) {
+    public GameMap getMap(long[][] teamMemory, String mapName) {
         XMLMapHandler handler = XMLMapHandler.loadMap(mapName,
                 TestMapGenerator.MAP_PATH);
 
-        return handler.createGameWorld("", "", teamMemory);
-    }
-
-    /**
-     * Sets unit-test-mode so that the engine will not try to instrument any
-     * player code. It's not necessary for these tests.
-     */
-    @Before
-    public void prepare() {
-        Config.getGlobalConfig().setBoolean("bc.engine.unit-test-mode", true);
+        return handler.getParsedMap();
     }
 
     /**
@@ -69,9 +60,8 @@ public class XMLMapHandlerTest {
         GameMap inputMap = gen.getMap("basicMap");
 
         long[][] teamMemory = new long[2][32];
-        GameWorld world = getMap(teamMemory, "basicMap");
-        GameMap outputMap = world.getGameMap();
+        GameMap outputMap = getMap(teamMemory, "basicMap");
 
-        assertTrue(inputMap.equivalentTo(outputMap));
+        assertTrue(inputMap.equals(outputMap));
     }
 }


### PR DESCRIPTION
There seems like a lot going on here, but I only changed a few things:
- GameMap now knows about the initial robots on the map
- XMLMapHandler creates and returns a GameMap instead of a GameWorld
- GameWorld initializes its own robots when created, instead of having XMLMapHandler do it

I was also able to remove unit-test-mode, since GameWorld doesn't need to be touched by tests now. (Yet. Its time will come.)

TODO: check that GameMap is being serialized into XML correctly. Tests pass, so you'd think it is, but hey, it's good to be sure.
