### PR TITLE
Infection bug

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -159,7 +159,10 @@ public class GameWorld implements SignalHandler {
                 this.controlProvider.runRobot(robot);
                 robot.setBytecodesUsed(this.controlProvider.getBytecodesUsed(robot));
                 robot.processEndOfTurn();
-                if (this.controlProvider.getTerminated(robot)) {
+                // If the robot terminates but the death signal has not yet
+                // been visited:
+                if (this.controlProvider.getTerminated(robot) && gameObjectsByID
+                        .get(id) != null) {
                     robot.suicide();
                 }
             }

--- a/src/main/battlecode/world/InternalRobot.java
+++ b/src/main/battlecode/world/InternalRobot.java
@@ -382,8 +382,6 @@ public class InternalRobot {
         decrementDelays(); // expends supply to decrement delays
 
         this.currentBytecodeLimit = type.bytecodeLimit;
-
-        processBeingInfected();
     }
 
     public void processEndOfTurn() {
@@ -410,6 +408,8 @@ public class InternalRobot {
             gameWorld.visitSignal(movementSignal);
             movementSignal = null;
         }
+
+        processBeingInfected();
     }
 
     public void processEndOfRound() {}


### PR DESCRIPTION
Addresses https://github.com/battlecode/battlecode-server/issues/81

Moved infection damage to the end of a turn instead of the beginning (to mirror Pokemon poison damage).

There was a bug where if a robot died on its own turn due to infection, the game would crash. This fixes it. Essentially it would try to suicide() when it had already died due to infection.
