### PR TITLE
Xml handler fix

### DIFF
--- a/src/main/battlecode/world/XMLMapHandler.java
+++ b/src/main/battlecode/world/XMLMapHandler.java
@@ -636,10 +636,10 @@ public class XMLMapHandler extends DefaultHandler {
                         map[currentCol][currentRow].setRubbleValue(rubbleVal);
                     } else { // Else, treat it as an old map
                         double value = Double.parseDouble(dataSoFar.substring(letterIdx));
-                        if (letters.equals("n"))
-                            map[currentCol][currentRow].setRubbleValue(value);
-                        else if (letters.equals("p"))
+                        if (letters.equals("p")) // If explicitly used for parts
                             map[currentCol][currentRow].setPartsValue(value);  
+                        else        // Else, assume it means rubble
+                            map[currentCol][currentRow].setRubbleValue(value);
                     }
                 }
 


### PR DESCRIPTION
Now works with map files generated by the new map editor, allowing both rubble and parts on the same tiles. Wait until map editor is updated before merging.

What needs to change in map editor:
- Use actual names of robotTypes ("ZOMBIEDEN" instead of "DEN", "STANDARDZOMBIE" instead of "STANDARD", etc.)
- Add a line specifying terrain symbol (<symbol type="TERRAIN" character="NN"/>)
- Map editor currently outputs a file mirrored about the vertical axis (not too important)
- Default height (20) of map editor is out of bounds (minimum 30) (not too important)
