### PR TITLE
Fix bug where bytecode usage is always maximum

### DIFF
--- a/src/main/battlecode/instrumenter/inject/RobotMonitor.java
+++ b/src/main/battlecode/instrumenter/inject/RobotMonitor.java
@@ -132,8 +132,6 @@ public final class RobotMonitor {
      * Must be called from the robot's main thread.
      */
     public static void pause() {
-        bytecodesLeft = 0;
-
         pauser.pause();
 
         reactivate();

--- a/src/test/battlecode/instrumenter/SandboxedRobotPlayerTest.java
+++ b/src/test/battlecode/instrumenter/SandboxedRobotPlayerTest.java
@@ -93,4 +93,16 @@ public class SandboxedRobotPlayerTest {
         assertFalse(player.getTerminated());
 
     }
+
+    @Test
+    public void testBytecodeCountsCorrect() throws Exception {
+        SandboxedRobotPlayer player = new SandboxedRobotPlayer("testplayerclock", "RobotPlayer", rc, 0);
+        player.setBytecodeLimit(10000);
+
+        player.step();
+
+        verify(rc).broadcast(0, 0);
+        // broadcast() is 25 bytecodes, +3 extra
+        assertEquals(player.getBytecodesUsed(), 28);
+    }
 }


### PR DESCRIPTION
Addresses: https://github.com/battlecode/battlecode-client/issues/28

Right now bytecode usage is always the maximum value. I think this fixes it? I'm not sure if there are unintended side effects or not.
