### PR TITLE
Enable lambdas in instrumented java code (and some other Java 8 features)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.DS_Store
 /testreport
 *~
+/instrumented

--- a/src/main/battlecode/instrumenter/IndividualClassLoader.java
+++ b/src/main/battlecode/instrumenter/IndividualClassLoader.java
@@ -8,6 +8,8 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
@@ -159,7 +161,6 @@ public class IndividualClassLoader extends ClassLoader {
                 byte[] classBytes;
                 try {
                     classBytes = instrument(name, false, teamPackageName);
-                    //dumpToFile(name,classBytes);
                 } catch (InstrumentationException ie) {
                     teamsWithErrors.add(teamPackageName);
                     throw ie;
@@ -209,5 +210,15 @@ public class IndividualClassLoader extends ClassLoader {
         ClassVisitor cv = new InstrumentingClassVisitor(cw, teamPackageName, false, checkDisallowed);
         cr.accept(cv, 0);        //passing false lets debug info be included in the transformation, so players get line numbers in stack traces
         return cw.toByteArray();
+    }
+
+    @SuppressWarnings("unused")
+    private void dumpToFile(String name, byte[] bytes) {
+        try {
+            Files.write(Paths.get("instrumented", name + ".class"), bytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 }

--- a/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
+++ b/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
@@ -101,13 +101,17 @@ public class ClassReferenceUtil {
         if (className.startsWith("instrumented/"))
             return false;
 
-        if (className.startsWith("java/util/jar") ||
+        if (className.startsWith("java/util/invoke") || // Don't override JVM internals
+                className.startsWith("java/util/jar") ||
                 className.startsWith("java/util/zip") ||
+                className.startsWith("java/util/stream") ||
+                className.startsWith("java/util/function") ||
                 className.equals("java/util/Iterator") ||
                 className.equals("java/util/concurrent/TimeUnit"))
             return false;
 
         if (className.startsWith("java/util/") ||
+                className.startsWith("java/text") ||
                 className.startsWith("java/math/"))
             return true;
 

--- a/src/main/battlecode/instrumenter/bytecode/InstrumentingClassVisitor.java
+++ b/src/main/battlecode/instrumenter/bytecode/InstrumentingClassVisitor.java
@@ -112,7 +112,11 @@ public class InstrumentingClassVisitor extends ClassVisitor implements Opcodes {
      * @inheritDoc
      */
     public void visitInnerClass(String name, String outerName, String innerName, int access) {
-        super.visitInnerClass(ClassReferenceUtil.classReference(name, teamPackageName, checkDisallowed), ClassReferenceUtil.classReference(outerName, teamPackageName, checkDisallowed), innerName, access);
+        super.visitInnerClass(
+                ClassReferenceUtil.classReference(name, teamPackageName, checkDisallowed),
+                ClassReferenceUtil.classReference(outerName, teamPackageName, checkDisallowed),
+                innerName, access
+        );
     }
 
 }

--- a/src/main/battlecode/instrumenter/bytecode/resources/AllowedPackages.txt
+++ b/src/main/battlecode/instrumenter/bytecode/resources/AllowedPackages.txt
@@ -1,8 +1,12 @@
 java/io
 java/lang
+java/lang/invoke
 java/math
 java/util
+java/util/function
 java/util/regex
+java/util/stream
+java/text
 battlecode/common
 scala
 scala/collection

--- a/src/test/battlecode/instrumenter/IndividualClassLoaderTest.java
+++ b/src/test/battlecode/instrumenter/IndividualClassLoaderTest.java
@@ -189,4 +189,11 @@ public class IndividualClassLoaderTest {
             fail("Didn't outlaw illegal class: "+className);
         }
     }
+
+    @Test
+    public void testLambdas() throws Exception {
+        Class<?> c = l1.loadClass("instrumentertest.UsesLambda");
+
+        c.getMethod("run").invoke(null);
+    }
 }

--- a/src/test/battlecode/instrumenter/sample/instrumentertest/UsesLambda.java
+++ b/src/test/battlecode/instrumenter/sample/instrumentertest/UsesLambda.java
@@ -1,0 +1,27 @@
+package instrumentertest;
+
+import java.util.BitSet;
+import java.util.Comparator;
+import java.util.Scanner;
+import java.util.function.Predicate;
+
+/**
+ * @author james
+ */
+@SuppressWarnings("unused")
+public class UsesLambda {
+    public static void run() {
+        Predicate<Object> isNullObjectPredicate = o -> o == null;
+
+        isNullObjectPredicate.test("Hi!");
+        isNullObjectPredicate.test(null);
+
+        Comparator<Object> alwaysTheSame = (a, b) -> 0;
+
+        alwaysTheSame.compare("Hi", 12345);
+        alwaysTheSame.compare(null, null);
+
+        // Classes that use lambdas internally
+        BitSet s = new BitSet(27);
+    }
+}


### PR DESCRIPTION
Addresses #141.

Attempts to address #142, but fails because of a new problem: Scanner references Locale, which references JVM-internal classes (sun/), which we don't instrument because it can break things.

Also enables all of the java.util.function and java.util.stream classes, and lambdas (hooray!)