### PR TITLE
Message Exploit Fixed

### DIFF
--- a/src/main/battlecode/common/MapLocation.java
+++ b/src/main/battlecode/common/MapLocation.java
@@ -144,6 +144,10 @@ public final class MapLocation implements Serializable, Comparable<MapLocation> 
      * @battlecode.doc.costlymethod
      */
     public final Direction directionTo(MapLocation location) {
+        if(location == null) {
+            return null;
+        }
+        
         double dx = location.x - this.x;
         double dy = location.y - this.y;
 

--- a/src/main/battlecode/common/Signal.java
+++ b/src/main/battlecode/common/Signal.java
@@ -119,13 +119,18 @@ public class Signal implements Serializable {
     /**
      * Returns the message associated with this signal, or null if the signal
      * was a basic (regular) signal. If it's not null, the integer array will
-     * always have length 2.
+     * always have length 2. Returns a copy so this.message can't be
+     * modified by the receiver.
      *
      * @return the message associated with this signal, or null if the signal
      * had no message.
      */
     public int[] getMessage() {
-        return message;
+        if(message == null) {
+            return null;
+        } else {
+            return message.clone();
+        }
     }
 
     /**


### PR DESCRIPTION
Signal.getMessage() now returns a copy of the array, stoping robots from modifying a signal that another one sent (issue #174). I added a test case, which was confirmed failing before fixing the exploit.

Also fixed #173, because it was simple.