### PR TITLE
Added messaging restrictions

### DIFF
--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -108,7 +108,20 @@ public interface GameConstants {
 
     /** Number of turns that elapse for the zombie outbreak level to increase */
     int OUTBREAK_TIMER = 300;
+    
+    // *********************************
+    // ****** MESSAGING ****************
+    // *********************************
 
+    /** The maximum size of the message queue. Any more messages push the oldest message out */
+    int SIGNAL_QUEUE_MAX_SIZE = 1000;
+    
+    /** The maximum number of basic signals a robot can send per turn */
+    int BASIC_SIGNALS_PER_TURN = 5;
+    
+    /** The maximum number of message signals a robot can send per turn */
+    int MESSAGE_SIGNALS_PER_TURN = 20;
+    
     // *********************************
     // ****** GAMEPLAY PROPERTIES ******
     // *********************************

--- a/src/main/battlecode/instrumenter/SandboxedRobotPlayer.java
+++ b/src/main/battlecode/instrumenter/SandboxedRobotPlayer.java
@@ -175,6 +175,8 @@ public class SandboxedRobotPlayer {
                 pauseMethod.invoke(null);
                 // Run the robot!
                 runMethod.invoke(null, robotController);
+                // If we get here, we've returned from the 'run' method. Tell the user.
+                System.out.println("Robot returned!");
             } catch (final IllegalAccessException e) {
                 ErrorReporter.report(e, true);
             } catch (final InvocationTargetException e) {

--- a/src/main/battlecode/instrumenter/SandboxedRobotPlayer.java
+++ b/src/main/battlecode/instrumenter/SandboxedRobotPlayer.java
@@ -175,8 +175,6 @@ public class SandboxedRobotPlayer {
                 pauseMethod.invoke(null);
                 // Run the robot!
                 runMethod.invoke(null, robotController);
-                // If we get here, we've returned from the 'run' method. Tell the user.
-                System.out.println("Robot returned!");
             } catch (final IllegalAccessException e) {
                 ErrorReporter.report(e, true);
             } catch (final InvocationTargetException e) {

--- a/src/main/battlecode/world/InternalRobot.java
+++ b/src/main/battlecode/world/InternalRobot.java
@@ -36,6 +36,8 @@ public class InternalRobot {
     private int roundsAlive;
     private int buildDelay;
     private int repairCount;
+    private int basicSignalCount;
+    private int messageSignalCount;
 
     /**
      * Used to avoid recreating the same RobotInfo object over and over.
@@ -72,6 +74,8 @@ public class InternalRobot {
         this.zombieInfectedTurns = 0;
         this.viperInfectedTurns = 0;
         this.repairCount = 0;
+        this.basicSignalCount = 0;
+        this.messageSignalCount = 0;
 
         this.controlBits = 0;
 
@@ -151,7 +155,15 @@ public class InternalRobot {
     public int getRepairCount() {
         return repairCount;
     }
+    
+    public int getBasicSignalCount() {
+        return basicSignalCount;
+    }
 
+    public int getMessageSignalCount() {
+        return messageSignalCount;
+    }
+    
     public double getMaxHealth() {
         return maxHealth;
     }
@@ -319,6 +331,9 @@ public class InternalRobot {
 
     public void receiveSignal(Signal mess) {
         signalqueue.add(mess);
+        if(signalqueue.size() > GameConstants.SIGNAL_QUEUE_MAX_SIZE) {
+            signalqueue.remove(0);
+        }
     }
 
     public Signal retrieveNextSignal() {
@@ -335,6 +350,14 @@ public class InternalRobot {
             queue[i] = signalqueue.remove(0);
         }
         return queue;
+    }
+    
+    public void incrementBasicSignalCount() {
+        basicSignalCount++;
+    }
+    
+    public void incrementMessageSignalCount() {
+        messageSignalCount++;
     }
 
     // *********************************
@@ -400,6 +423,8 @@ public class InternalRobot {
     public void processBeginningOfTurn() {
         decrementDelays();
         repairCount = 0;
+        basicSignalCount = 0;
+        messageSignalCount = 0;
 
         this.currentBytecodeLimit = getType().bytecodeLimit;
     }

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -31,7 +31,7 @@ public final class RobotControllerImpl implements RobotController {
      * The robot this controller controls.
      */
     private final InternalRobot robot;
-
+    
     /**
      * Create a new RobotControllerImpl
      *
@@ -536,8 +536,14 @@ public final class RobotControllerImpl implements RobotController {
             throw new GameActionException(CANT_DO_THAT, "Cannot broadcast " +
                     "with negative radius.");
         }
+        if (robot.getBasicSignalCount() >= GameConstants.BASIC_SIGNALS_PER_TURN) {
+            throw new GameActionException(CANT_DO_THAT, "Cannot broadcast " +
+                    "more than "+GameConstants.BASIC_SIGNALS_PER_TURN + " basic " +
+                    "signals per turn");
+        }
         gameWorld.visitBroadcastSignal(new BroadcastSignal(getID(), new
                 Signal(getLocation(), getID(), getTeam()), radiusSquared));
+        robot.incrementBasicSignalCount();
     }
 
     @Override
@@ -553,9 +559,15 @@ public final class RobotControllerImpl implements RobotController {
             throw new GameActionException(CANT_DO_THAT, "Cannot broadcast " +
                     "with negative radius.");
         }
+        if (robot.getMessageSignalCount() >= GameConstants.MESSAGE_SIGNALS_PER_TURN) {
+            throw new GameActionException(CANT_DO_THAT, "Cannot broadcast " +
+                    "more than "+GameConstants.MESSAGE_SIGNALS_PER_TURN + " message " +
+                    "signals per turn");
+        }
         gameWorld.visitBroadcastSignal(new BroadcastSignal(getID(), new Signal
                 (getLocation(), getID(), getTeam(), message1, message2),
                 radiusSquared));
+        robot.incrementMessageSignalCount();
     }
 
     // ***********************************


### PR DESCRIPTION
"new messaging restrictions: a message queue can only have 1000 messages maximum (older messages get kicked out). A robot can only send 5 basic signals/turn and 20 message signals/turn.
this is to prevent robots from getting thousands of message in their queue and then emptying it, causing the client to freeze up (this happens)" - David