### PR TITLE
Fix exception with clearing rubble off map

### DIFF
--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -421,13 +421,15 @@ public interface RobotController {
     // ***********************************
 
     /**
-     * Clears rubble in the specified direction. If you clear a direction
-     * that is off the map, nothing happens.
+     * Clears rubble in the specified direction. If you clear rubble in a
+     * direction that is off the map, an exception will be thrown. If you
+     * clear rubble in a location with no rubble, nothing happens.
      *
      * @param dir
      *            the direction to clear rubble in.
-     * @throws GameActionException if the robot has core delay or if you are
-     * not allowed to clear rubble.
+     * @throws GameActionException if the robot has core delay, if you are
+     * not allowed to clear rubble, or if you clear in a direction that is
+     * off the map.
      *
      * @battlecode.doc.costlymethod
      */

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -426,8 +426,20 @@ public final class RobotControllerImpl implements RobotController {
                     "the direction OMNI.");
         }
 
+        MapLocation target = getLocation().add(dir);
+
+        // Ignore off map locations.
+        if (!gameWorld.getGameMap().onTheMap(target)) {
+            return;
+        }
+
+        // Ignore locations with no rubble to clear.
+        if (gameWorld.getRubble(target) == 0) {
+            return;
+        }
+
         robot.activateCoreAction(new ClearRubbleSignal(robot.getID(),
-                        getLocation().add(dir), (int) (robot.getType()
+                        target, (int) (robot.getType()
                         .movementDelay)),
                 robot.getType().cooldownDelay, robot.getType().movementDelay);
     }

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -430,7 +430,8 @@ public final class RobotControllerImpl implements RobotController {
 
         // Ignore off map locations.
         if (!gameWorld.getGameMap().onTheMap(target)) {
-            return;
+            throw new GameActionException(CANT_DO_THAT, "You cannot clear " +
+                    "rubble in a location that is off the map.");
         }
 
         // Ignore locations with no rubble to clear.

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -1042,7 +1042,7 @@ public class RobotControllerTest {
         int oX = game.getOriginX();
         int oY = game.getOriginY();
         final int soldier1 = game.spawn(oX, oY, RobotType.SOLDIER,Team.A);
-        final int soldier2 = game.spawn(oX+3, oY+3, RobotType.SOLDIER,Team.A);
+        final int soldier2 = game.spawn(oX + 3, oY + 3, RobotType.SOLDIER, Team.A);
         final int soldier3 = game.spawn(oX+6, oY+6, RobotType.SOLDIER,Team.B);
         final int soldier4 = game.spawn(oX+10, oY+10, RobotType.SOLDIER,Team.A);
         final int zombie = game.spawn(oX+4, oY+2, RobotType.STANDARDZOMBIE, Team.ZOMBIE);
@@ -1054,17 +1054,19 @@ public class RobotControllerTest {
             if (id == soldier1) {
                 assertTrue(rc.canSenseRobot(soldier2));
                 assertFalse(rc.canSenseRobot(soldier3));
-                RobotInfo[] hostiles = rc.senseHostileRobots(soldier1Bot.getLocation(),-1);
-                assertEquals(hostiles.length,1);
+                RobotInfo[] hostiles = rc.senseHostileRobots(soldier1Bot
+                        .getLocation(), -1);
+                assertEquals(hostiles.length, 1);
                 RobotInfo[] allRobots = rc.senseNearbyRobots();
                 assertEquals(allRobots.length, 2);
             } else if (id == soldier2) {
                 assertTrue(rc.canSenseRobot(soldier1));
                 assertTrue(rc.canSenseRobot(soldier3));
-                RobotInfo[] hostiles = rc.senseHostileRobots(soldier2Bot.getLocation(),2);
-                assertEquals(hostiles.length,1);
-                hostiles = rc.senseHostileRobots(soldier2Bot.getLocation(),-1);
-                assertEquals(hostiles.length,2);
+                RobotInfo[] hostiles = rc.senseHostileRobots(soldier2Bot
+                        .getLocation(), 2);
+                assertEquals(hostiles.length, 1);
+                hostiles = rc.senseHostileRobots(soldier2Bot.getLocation(), -1);
+                assertEquals(hostiles.length, 2);
                 RobotInfo[] allRobots = rc.senseNearbyRobots();
                 assertEquals(allRobots.length, 3);
             } else if (id == soldier3) {
@@ -1167,7 +1169,7 @@ public class RobotControllerTest {
     }
 
     /**
-     * Make sure no error is thrown if you try to clear rubble on an off map
+     * Make sure an error is thrown if you try to clear rubble on an off map
      * location.
      */
     @Test
@@ -1182,7 +1184,13 @@ public class RobotControllerTest {
 
         game.round((id, rc) -> {
             if (id == bot1) {
-                rc.clearRubble(Direction.NORTH);
+                boolean exception = false;
+                try {
+                    rc.clearRubble(Direction.NORTH);
+                } catch (GameActionException e) {
+                    exception = true;
+                }
+                assertTrue(exception);
             }
         });
     }

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -1165,4 +1165,25 @@ public class RobotControllerTest {
                 * GameConstants.PART_INCOME_UNIT_PENALTY, EPSILON);
         assertEquals(3, game.getWorld().getRobotCount(Team.A));
     }
+
+    /**
+     * Make sure no error is thrown if you try to clear rubble on an off map
+     * location.
+     */
+    @Test
+    public void testClearRubbleOffMap() throws GameActionException {
+        TestMapGenerator mapGen = new TestMapGenerator(10, 10, 100);
+        GameMap map = mapGen.getMap("test");
+        TestGame game = new TestGame(map);
+        int oX = game.getOriginX();
+        int oY = game.getOriginY();
+        final int bot1 = game.spawn(oX, oY, RobotType.ARCHON, Team.A);
+
+
+        game.round((id, rc) -> {
+            if (id == bot1) {
+                rc.clearRubble(Direction.NORTH);
+            }
+        });
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/battlecode/battlecode-server/issues/193

No delays are accumulated nor are signals sent to the client when an attempt is made to clear rubble off map or on a tile with no rubble.