### PR TITLE
Fixed "visitDeathSignal of nonexistent robot"

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -165,7 +165,10 @@ public class GameWorld implements SignalHandler {
                 robot.processBeginningOfTurn();
                 this.controlProvider.runRobot(robot);
                 robot.setBytecodesUsed(this.controlProvider.getBytecodesUsed(robot));
-                robot.processEndOfTurn();
+                
+                if(robot.getHealthLevel() > 0) { // Only processEndOfTurn if robot is still alive
+                    robot.processEndOfTurn();
+                }
                 // If the robot terminates but the death signal has not yet
                 // been visited:
                 if (this.controlProvider.getTerminated(robot) && gameObjectsByID


### PR DESCRIPTION
Stops robots from dying twice sometimes when they attack themselves. Error in #207 was reproduced, and this stops it. Currently doesn't have a test case, but I don't think one is necessary.