### PR TITLE
canBuildX now checks cooldown status

### DIFF
--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -931,8 +931,7 @@ public interface RobotController {
      * Returns whether the robot can build a robot of the given type in the
      * given direction. Checks dependencies, cooldown turns remaining,
      * bullet costs, whether the robot can build, and that the given direction is
-     * not blocked. Does not check if a robot has sufficiently low coreDelay or
-     * not.
+     * not blocked.
      *
      * @param dir the direction to build in.
      * @param type the robot type to build.
@@ -947,8 +946,7 @@ public interface RobotController {
      * Returns whether the robot can build a bullet tree in the given direction.
      * Checks dependencies, cooldown turns remaining, bullet costs,
      * whether the robot can build, and that the given direction is
-     * not blocked. Does not check if a robot has sufficiently low coreDelay or
-     * not.
+     * not blocked.
      *
      * @param dir the direction to build in.
      * @return whether it is possible to build a bullet tree in the
@@ -956,8 +954,19 @@ public interface RobotController {
      *
      * @battlecode.doc.costlymethod
      */
-    boolean canBuildTree(Direction dir);
+    boolean canPlantBulletTree(Direction dir);
 
+    /**
+     * Returns whether the robot can hire a gardener in the given direction.
+     * Checks dependencies, cooldown turns remaining, bullet costs,
+     * whether the robot can build, and that the given direction is
+     * not blocked.
+     * 
+     * @param dir the direction to build in.
+     * @return whether it is possible to hire a gardener in the given direction.
+     */
+    boolean canHireGardener(Direction dir);
+    
     /**
      * Hires a Gardener in the given direction. This is a core action.
      *
@@ -972,7 +981,6 @@ public interface RobotController {
 
     /**
      * Plants/Builds a robot of the given type in the given direction.
-     * This is a core action.
      *
      * @param dir the direction to spawn the unit.
      * @param type the type of robot to build
@@ -982,7 +990,7 @@ public interface RobotController {
      *
      * @battlecode.doc.costlymethod
      */
-    void plantRobot(RobotType type, Direction dir) throws GameActionException;
+    void buildRobot(RobotType type, Direction dir) throws GameActionException;
 
     /**
      * Plants a bullet tree in the given direction. This is a core action.

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -927,7 +927,7 @@ public final class RobotControllerImpl implements RobotController {
     }
 
     private void assertCanBuildTree(Direction dir) throws GameActionException{
-        if(!canBuildTree(dir)){
+        if(!canPlantBulletTree(dir)){
             throw new GameActionException(CANT_DO_THAT,
                     "Can't build a bullet tree in given direction, possibly due to " +
                             "insufficient bullet supply, this robot can't build, " +
@@ -966,7 +966,7 @@ public final class RobotControllerImpl implements RobotController {
     }
 
     @Override
-    public boolean canBuildTree(Direction dir) {
+    public boolean canPlantBulletTree(Direction dir) {
         assertNotNull(dir);
         boolean hasBuildRequirements = hasTreeBuildRequirements();
         float spawnDist = getType().bodyRadius +
@@ -978,6 +978,11 @@ public final class RobotControllerImpl implements RobotController {
                 gameWorld.getObjectInfo().isEmpty(spawnLoc, GameConstants.BULLET_TREE_RADIUS);
         boolean cooldownExpired = isBuildReady();
         return hasBuildRequirements && isClear && cooldownExpired;
+    }
+    
+    @Override
+    public boolean canHireGardener(Direction dir) {
+        return canBuildRobot(RobotType.GARDENER,dir);
     }
 
     @Override
@@ -1000,7 +1005,7 @@ public final class RobotControllerImpl implements RobotController {
     }
 
     @Override
-    public void plantRobot(RobotType type, Direction dir) throws GameActionException {
+    public void buildRobot(RobotType type, Direction dir) throws GameActionException {
         assertNotNull(dir);
         assertCanBuildRobot(type, dir);
 


### PR DESCRIPTION
Resolves #256 , additional naming changes

I changed the naming of robotcontroller methods to canPlantBulletTree/plantBulletTree, canBuildRobot/buildRobot, canHireGardener/hireGardener to attempt to reduce confusion. There might be other inconsistencies elsewhere, but at least the player-facing code is a bit more consistent now.

This will break current players, but should be a simple fix.