### PR TITLE
Deal with bytecode exploits

### DIFF
--- a/src/main/battlecode/instrumenter/inject/RobotMonitor.java
+++ b/src/main/battlecode/instrumenter/inject/RobotMonitor.java
@@ -142,7 +142,10 @@ public final class RobotMonitor {
      */
     @SuppressWarnings("unused")
     public static void incrementBytecodesWithoutInterrupt(int numBytecodes) {
-        bytecodesToRemove += numBytecodes;
+        // Several potential exploits mean this argument may be passed a negative value.
+        // It's easier to deal with this here than in the instrumenter.
+        if (numBytecodes > 0)
+            bytecodesToRemove += numBytecodes;
     }
 
     /**


### PR DESCRIPTION
See #299 . It may also be possible to overflow the bytecode counter to negative values by initializing arrays of Integer.MAX_VALUE size, but I couldn't find a way to catch the resulting OutOfMemoryError.