### PR TITLE
Change plantBulletTree to plantTree and canPlantBulletTree to canPlantTree

### DIFF
--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -944,7 +944,7 @@ public strictfp interface RobotController {
      *
      * @battlecode.doc.costlymethod
      */
-    boolean canPlantBulletTree(Direction dir);
+    boolean canPlantTree(Direction dir);
 
     /**
      * Returns whether the robot can hire a gardener in the given direction.
@@ -992,7 +992,7 @@ public strictfp interface RobotController {
      *
      * @battlecode.doc.costlymethod
      */
-    void plantBulletTree(Direction dir) throws  GameActionException;
+    void plantTree(Direction dir) throws  GameActionException;
 
     // ***********************************
     // ****** OTHER ACTION METHODS *******

--- a/src/main/battlecode/instrumenter/bytecode/resources/MethodCosts.txt
+++ b/src/main/battlecode/instrumenter/bytecode/resources/MethodCosts.txt
@@ -37,7 +37,7 @@ battlecode/common/RobotController/canInteractWithRobot              5     true
 battlecode/common/RobotController/canInteractWithTree               5     true
 battlecode/common/RobotController/canMove                           10    true
 battlecode/common/RobotController/canPentadShot                     5     true
-battlecode/common/RobotController/canPlantBulletTree                10    true
+battlecode/common/RobotController/canPlantTree                      10    true
 battlecode/common/RobotController/canRepair                         5     true
 battlecode/common/RobotController/canSenseAllOfCircle               5     true
 battlecode/common/RobotController/canSenseBullet                    5     true
@@ -86,7 +86,7 @@ battlecode/common/RobotController/isLocationOccupiedByRobot         20    true
 battlecode/common/RobotController/isLocationOccupiedByTree          20    true
 battlecode/common/RobotController/move                              0     true
 battlecode/common/RobotController/onTheMap                          5     true
-battlecode/common/RobotController/plantBulletTree                   0     true
+battlecode/common/RobotController/plantTree                         0     true
 battlecode/common/RobotController/readBroadcast                     5     true
 battlecode/common/RobotController/repair                            0     true
 battlecode/common/RobotController/resign                            0     true

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -942,7 +942,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
     }
 
     private void assertCanBuildTree(Direction dir) throws GameActionException{
-        if(!canPlantBulletTree(dir)){
+        if(!canPlantTree(dir)){
             throw new GameActionException(CANT_DO_THAT,
                     "Can't build a bullet tree in given direction, possibly due to " +
                             "insufficient bullet supply, this robot can't build, " +
@@ -981,7 +981,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
     }
 
     @Override
-    public boolean canPlantBulletTree(Direction dir) {
+    public boolean canPlantTree(Direction dir) {
         assertNotNull(dir);
         boolean hasBuildRequirements = hasTreeBuildRequirements();
         float spawnDist = getType().bodyRadius +
@@ -1039,7 +1039,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
     }
 
     @Override
-    public void plantBulletTree(Direction dir) throws GameActionException {
+    public void plantTree(Direction dir) throws GameActionException {
         assertNotNull(dir);
         assertIsBuildReady();
         assertCanBuildTree(dir);

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -369,12 +369,12 @@ public class RobotControllerTest {
         
         game.round((id, rc) -> {
             if (id != gardenerA) return;
-            assertFalse(rc.canPlantBulletTree(Direction.getWest())); // tree in way
-            assertTrue(rc.canPlantBulletTree(Direction.getNorth())); // unobstructed
-            assertTrue(rc.canPlantBulletTree(Direction.getEast())); // unobstructed
-            rc.plantBulletTree(Direction.getEast());
+            assertFalse(rc.canPlantTree(Direction.getWest())); // tree in way
+            assertTrue(rc.canPlantTree(Direction.getNorth())); // unobstructed
+            assertTrue(rc.canPlantTree(Direction.getEast())); // unobstructed
+            rc.plantTree(Direction.getEast());
             assertFalse(rc.canMove(Direction.getEast())); // tree now in the way
-            assertFalse(rc.canPlantBulletTree(Direction.getNorth())); // has already planted this turn
+            assertFalse(rc.canPlantTree(Direction.getNorth())); // has already planted this turn
             TreeInfo[] trees = rc.senseNearbyTrees();
             assertEquals(trees.length,2);
             TreeInfo[] bulletTrees = rc.senseNearbyTrees(-1, rc.getTeam());


### PR DESCRIPTION
What do you think of slightly shortening the name of those methods?

This makes the API more consistent, since other methods (like canInteractWithTree) call trees Tree instead of BulletTree.

If we merge this, I'll fix the players too.