### PR TITLE
Consistency in javadocs

### DIFF
--- a/src/main/battlecode/common/BodyInfo.java
+++ b/src/main/battlecode/common/BodyInfo.java
@@ -6,32 +6,32 @@ package battlecode.common;
 public interface BodyInfo {
 
     /**
-     * @return the id of the body
+     * @return the id of the body.
      */
     int getID();
 
     /**
-     * @return the center location of this body
+     * @return the center location of this body.
      */
     MapLocation getLocation();
 
     /**
-     * @return the radius of this body
+     * @return the radius of this body.
      */
     float getRadius();
 
     /**
-     * @return true if this body is a robot, false otherwise
+     * @return true if this body is a robot; false otherwise.
      */
     boolean isRobot();
 
     /**
-     * @return true if this body is a tree, false otherwise
+     * @return true if this body is a tree; false otherwise.
      */
     boolean isTree();
 
     /**
-     * @return true if this body is a bullet, false otherwise
+     * @return true if this body is a bullet; false otherwise.
      */
     boolean isBullet();
 

--- a/src/main/battlecode/common/BodyInfo.java
+++ b/src/main/battlecode/common/BodyInfo.java
@@ -6,31 +6,43 @@ package battlecode.common;
 public interface BodyInfo {
 
     /**
-     * @return the id of the body.
+     * Returns the ID of this body.
+     *
+     * @return the ID of this body.
      */
     int getID();
 
     /**
+     * Returns the center location of this body.
+     *
      * @return the center location of this body.
      */
     MapLocation getLocation();
 
     /**
+     * Returns the radius of this body.
+     *
      * @return the radius of this body.
      */
     float getRadius();
 
     /**
+     * Returns whether this body is a robot.
+     *
      * @return true if this body is a robot; false otherwise.
      */
     boolean isRobot();
 
     /**
+     * Returns whether this body is a tree.
+     *
      * @return true if this body is a tree; false otherwise.
      */
     boolean isTree();
 
     /**
+     * Returns whether this body is a bullet.
+     *
      * @return true if this body is a bullet; false otherwise.
      */
     boolean isBullet();

--- a/src/main/battlecode/common/BulletInfo.java
+++ b/src/main/battlecode/common/BulletInfo.java
@@ -14,17 +14,17 @@ public class BulletInfo implements BodyInfo{
 
     /**
      * The speed at which the bullet is traveling in
-     * terms of units per turn
+     * terms of units per turn.
      */
     public final float speed;
 
     /**
-     * The damage this bullet deals on impact
+     * The damage this bullet deals on impact.
      */
     public final float damage;
 
     /**
-     * The direction in which the bullet is moving
+     * The direction in which the bullet is moving.
      */
     public final Direction dir;
 
@@ -42,21 +42,21 @@ public class BulletInfo implements BodyInfo{
     }
 
     /**
-     * @return the speed at which the bullet is traveling in units per turn
+     * @return the speed at which the bullet is traveling in units per turn.
      */
     public float getSpeed() {
         return speed;
     }
 
     /**
-     * @return the damage this bullet deals on impact
+     * @return the damage this bullet deals on impact.
      */
     public float getDamage() {
         return damage;
     }
 
     /**
-     * @return the direction in which the bullet is moving
+     * @return the direction in which the bullet is moving.
      */
     public Direction getDir() {
         return dir;

--- a/src/main/battlecode/common/BulletInfo.java
+++ b/src/main/battlecode/common/BulletInfo.java
@@ -13,8 +13,7 @@ public class BulletInfo implements BodyInfo{
     public final int ID;
 
     /**
-     * The speed at which the bullet is traveling in
-     * terms of units per turn.
+     * The speed of this bullet, in units per turn.
      */
     public final float speed;
 
@@ -24,12 +23,12 @@ public class BulletInfo implements BodyInfo{
     public final float damage;
 
     /**
-     * The direction in which the bullet is moving.
+     * The direction in which this bullet is moving.
      */
     public final Direction dir;
 
     /**
-     * The current location of the tree.
+     * The current location of this bullet.
      */
     public final MapLocation location;
 
@@ -42,13 +41,17 @@ public class BulletInfo implements BodyInfo{
     }
 
     /**
-     * @return the speed at which the bullet is traveling in units per turn.
+     * Returns the speed of this bullet, in units per turn
+     *
+     * @return the speed of this bullet.
      */
     public float getSpeed() {
         return speed;
     }
 
     /**
+     * Returns the damage this bullet deals on impact.
+     *
      * @return the damage this bullet deals on impact.
      */
     public float getDamage() {
@@ -56,7 +59,9 @@ public class BulletInfo implements BodyInfo{
     }
 
     /**
-     * @return the direction in which the bullet is moving.
+     * Returns the direction in which this bullet is moving.
+     *
+     * @return the direction in which this bullet is moving.
      */
     public Direction getDir() {
         return dir;

--- a/src/main/battlecode/common/Direction.java
+++ b/src/main/battlecode/common/Direction.java
@@ -25,7 +25,7 @@ public final strictfp class Direction {
     /**
      * Creates a new Direction instance to represent the direction
      * in which the vector created by dx and dy points. Requires
-     * dx or dy to be non-zero
+     * dx or dy to be non-zero.
      *
      * @param dx the x component of the vector
      * @param dy the y component of the vector
@@ -40,7 +40,7 @@ public final strictfp class Direction {
     /**
      * Creates a new Direction instance to represent the direction
      * in which the vector from start to finish points. Requires
-     * start and finish to not be the same location
+     * start and finish to not be the same location.
      *
      * @param start  the starting point of the vector
      * @param finish the ending point of the vector
@@ -50,7 +50,7 @@ public final strictfp class Direction {
     }
 
     /**
-     * Creates a instance of Direction that represents pointing east (right on screen)
+     * Creates a instance of Direction that represents pointing east (right on screen).
      *
      * @return Direction instance facing east
      * @battlecode.doc.costlymethod
@@ -60,7 +60,7 @@ public final strictfp class Direction {
     }
 
     /**
-     * Creates a instance of Direction that represents pointing north (up on screen)
+     * Creates a instance of Direction that represents pointing north (up on screen).
      *
      * @return Direction instance facing north
      * @battlecode.doc.costlymethod
@@ -70,7 +70,7 @@ public final strictfp class Direction {
     }
 
     /**
-     * Creates a instance of Direction that represents pointing west (left on screen)
+     * Creates a instance of Direction that represents pointing west (left on screen).
      *
      * @return Direction instance facing west
      * @battlecode.doc.costlymethod
@@ -80,7 +80,7 @@ public final strictfp class Direction {
     }
 
     /**
-     * Creates a instance of Direction that represents pointing south (down on screen)
+     * Creates a instance of Direction that represents pointing south (down on screen).
      *
      * @return Direction instance facing south
      * @battlecode.doc.costlymethod
@@ -114,7 +114,7 @@ public final strictfp class Direction {
     }
 
     /**
-     * Computes the angle in degrees at which this direction faces
+     * Computes the angle in degrees at which this direction faces.
      *
      * @return the angle in degrees this direction faces
      * @battlecode.doc.costlymethod
@@ -183,7 +183,7 @@ public final strictfp class Direction {
 
     /**
      * Computes the angle between the given direction and this direction in radians.
-     * Returned value will be in the range [0, Math.PI]
+     * Returned value will be in the range [0, Math.PI].
      *
      * @param other the direction you wish to find the angle between
      * @return the angle in radians between this direction and the given direction
@@ -201,7 +201,7 @@ public final strictfp class Direction {
 
     /**
      * Computes the angle between the given direction and this direction in degrees.
-     * Returned value will be in the range [0, 180]
+     * Returned value will be in the range [0, 180].
      *
      * @param other the direction you wish to find the angle between
      * @return the angle in degrees between this direction and the given direction

--- a/src/main/battlecode/common/Direction.java
+++ b/src/main/battlecode/common/Direction.java
@@ -52,7 +52,7 @@ public final strictfp class Direction {
     /**
      * Creates a instance of Direction that represents pointing east (right on screen).
      *
-     * @return Direction instance facing east
+     * @return Direction instance facing east.
      * @battlecode.doc.costlymethod
      */
     public static Direction getEast() {
@@ -62,7 +62,7 @@ public final strictfp class Direction {
     /**
      * Creates a instance of Direction that represents pointing north (up on screen).
      *
-     * @return Direction instance facing north
+     * @return Direction instance facing north.
      * @battlecode.doc.costlymethod
      */
     public static Direction getNorth() {
@@ -72,7 +72,7 @@ public final strictfp class Direction {
     /**
      * Creates a instance of Direction that represents pointing west (left on screen).
      *
-     * @return Direction instance facing west
+     * @return Direction instance facing west.
      * @battlecode.doc.costlymethod
      */
     public static Direction getWest() {
@@ -82,7 +82,7 @@ public final strictfp class Direction {
     /**
      * Creates a instance of Direction that represents pointing south (down on screen).
      *
-     * @return Direction instance facing south
+     * @return Direction instance facing south.
      * @battlecode.doc.costlymethod
      */
     public static Direction getSouth() {
@@ -94,7 +94,7 @@ public final strictfp class Direction {
      * units in this Direction.
      *
      * @param travelDist the total distance to travel
-     * @return the signed distance traveled on the x-axis
+     * @return the signed distance traveled on the x-axis.
      * @battlecode.doc.costlymethod
      */
     public float getDeltaX(float travelDist) {
@@ -106,7 +106,7 @@ public final strictfp class Direction {
      * units in this Direction.
      *
      * @param travelDist the total distance to travel
-     * @return the signed distance traveled on the x-axis
+     * @return the signed distance traveled on the x-axis.
      * @battlecode.doc.costlymethod
      */
     public float getDeltaY(float travelDist) {
@@ -116,7 +116,7 @@ public final strictfp class Direction {
     /**
      * Computes the angle in degrees at which this direction faces.
      *
-     * @return the angle in degrees this direction faces
+     * @return the angle in degrees this direction faces.
      * @battlecode.doc.costlymethod
      */
     public float getAngleDegrees() {
@@ -126,7 +126,7 @@ public final strictfp class Direction {
     /**
      * Computes the direction opposite this one.
      *
-     * @return the direction pointing in the opposite direction
+     * @return the direction pointing in the opposite direction.
      * @battlecode.doc.costlymethod
      */
     public Direction opposite() {
@@ -137,7 +137,7 @@ public final strictfp class Direction {
      * Computes the direction angleDegrees to the left (counter-clockwise)
      * of this one.
      *
-     * @param angleDegrees number of degrees to rotate.
+     * @param angleDegrees number of degrees to rotate
      * @return the direction angleDegrees degrees left of this one.
      * @battlecode.doc.costlymethod
      */
@@ -149,7 +149,7 @@ public final strictfp class Direction {
      * Computes the direction angleDegrees to the right (clockwise) of this
      * one.
      *
-     * @param angleDegrees number of degrees to rotate.
+     * @param angleDegrees number of degrees to rotate
      * @return the direction angleDegrees right of this one.
      * @battlecode.doc.costlymethod
      */
@@ -161,7 +161,7 @@ public final strictfp class Direction {
      * Computes the direction angleRads (radians) to the left (counter-clockwise)
      * of this one.
      *
-     * @param angleRads number of radians to rotate.
+     * @param angleRads number of radians to rotate
      * @return the direction angleRads left of this one.
      * @battlecode.doc.costlymethod
      */
@@ -173,7 +173,7 @@ public final strictfp class Direction {
      * Computes the direction angleRads (radians) to the right (clockwise) of
      * this one.
      *
-     * @param angleRads number of radians to rotate.
+     * @param angleRads number of radians to rotate
      * @return the direction angleRads right of this one.
      * @battlecode.doc.costlymethod
      */
@@ -187,7 +187,7 @@ public final strictfp class Direction {
      *
      * @param other the direction you wish to find the angle between
      * @return the angle in radians between this direction and the given direction
-     * in the range of [0, Math.PI]
+     * in the range of [0, Math.PI].
      * @battlecode.doc.costlymethod
      */
     public float radiansBetween(Direction other) {
@@ -205,7 +205,7 @@ public final strictfp class Direction {
      *
      * @param other the direction you wish to find the angle between
      * @return the angle in degrees between this direction and the given direction
-     * in the range of [0, 180]
+     * in the range of [0, 180].
      * @battlecode.doc.costlymethod
      */
     public float degreesBetween(Direction other) {

--- a/src/main/battlecode/common/GameActionException.java
+++ b/src/main/battlecode/common/GameActionException.java
@@ -23,8 +23,8 @@ public class GameActionException extends Exception {
 
     /**
      * Creates a GameActionException with the given type and message.
-     * @param type the type of the GameActionException.
-     * @param message the error message.
+     * @param type the type of the GameActionException
+     * @param message the error message
      */
     public GameActionException(GameActionExceptionType type, String message) {
         super(message);

--- a/src/main/battlecode/common/GameActionException.java
+++ b/src/main/battlecode/common/GameActionException.java
@@ -35,7 +35,7 @@ public class GameActionException extends Exception {
      * Gives the type of gameworld interaction that caused this GameActionException, which
      * was specified when this instance was constructed.
      *
-     * @return this GameActionException's type
+     * @return this GameActionException's type.
      */
     public GameActionExceptionType getType() {
         return type;

--- a/src/main/battlecode/common/GameActionExceptionType.java
+++ b/src/main/battlecode/common/GameActionExceptionType.java
@@ -14,7 +14,7 @@ public enum GameActionExceptionType {
      */
     NOT_ENOUGH_RESOURCE,
     /**
-     * Indicates when a robot tries to move into non-empty location.
+     * Indicates when a robot tries to move into a non-empty location.
      */
     CANT_MOVE_THERE,
     /**
@@ -22,13 +22,13 @@ public enum GameActionExceptionType {
      */
     NOT_ACTIVE,
     /**
-     * Indicates when a robot tries to sense a Robot that is no longer existant or no longer
+     * Indicates when a robot tries to sense a robot, bullet, or tree that no longer exists or is no longer
      * in this robot's sensor range.
      */
     CANT_SENSE_THAT,
     /**
      * Indicates when a robot tries to perform an action on a location that is outside
-     * its range..
+     * its range.
      */
     OUT_OF_RANGE,
     /**
@@ -41,7 +41,7 @@ public enum GameActionExceptionType {
      */
     NO_ROBOT_THERE,
     /**
-     * Indicates when a robot tries to perform an action on tree, but there is
+     * Indicates when a robot tries to perform an action on a tree, but there is
      * no suitable tree there.
      */
     NO_TREE_THERE,

--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -37,10 +37,10 @@ public interface GameConstants {
     /** The number of longs that your team can remember between games. */
     int TEAM_MEMORY_LENGTH = 32;
 
-    /** The number of indicator strings that a player can associate with a robot */
+    /** The number of indicator strings that a player can associate with a robot. */
     int NUMBER_OF_INDICATOR_STRINGS = 3;
 
-    /** The bytecode penalty that is imposed each time an exception is thrown */
+    /** The bytecode penalty that is imposed each time an exception is thrown. */
     int EXCEPTION_BYTECODE_PENALTY = 500;
 
     /** Maximum archons that can appear on a map (per team). */
@@ -50,33 +50,33 @@ public interface GameConstants {
     // ****** TREES ********************
     // *********************************
 
-    /** The max health of bullet trees */
+    /** The max health of bullet trees. */
     float BULLET_TREE_MAX_HEALTH = 50;
 
-    /** The radius of bullet trees */
+    /** The radius of bullet trees. */
     float BULLET_TREE_RADIUS = 1F;
 
-    /** The cost in bullets to spawn a bullet tree */
+    /** The cost in bullets to spawn a bullet tree. */
     float BULLET_TREE_COST = 50;
 
-    /** The amount of health bullet trees lose per turn from decay */
+    /** The amount of health bullet trees lose per turn from decay. */
     float BULLET_TREE_DECAY_RATE = BULLET_TREE_MAX_HEALTH / 100f;
 
-    /** The amount of bullets produced from one unit of health per bullet tree */
+    /** The amount of bullets produced from one unit of health per bullet tree. */
     float BULLET_TREE_BULLET_PRODUCTION_RATE = 1f / BULLET_TREE_MAX_HEALTH;
     
-    /** Number of cooldown turns robot must wait between planting trees */
+    /** Number of cooldown turns robot must wait between planting trees. */
     int BULLET_TREE_CONSTRUCTION_COOLDOWN = 10;
 
-    /** The min radius a neutral tree can have */
+    /** The min radius a neutral tree can have. */
     float NEUTRAL_TREE_MIN_RADIUS = .5F;
 
-    /** The max radius a neutral tree can have */
+    /** The max radius a neutral tree can have. */
     float NEUTRAL_TREE_MAX_RADIUS = 10;
 
     /**
-     * The rate at which the max health of neutral trees are determined;
-     * i.e. maxHealth = NEUTRAL_TREE_HEALTH_RATE * treeRadius
+     * The rate at which the max health of neutral trees are determined.
+     *      maxHealth = NEUTRAL_TREE_HEALTH_RATE * treeRadius
      */
     float NEUTRAL_TREE_HEALTH_RATE = 200;
 
@@ -91,7 +91,7 @@ public interface GameConstants {
     float TANK_BODY_DAMAGE = 2;
     
     /**
-     * Planted units (trees and non-gardener non-archon robots) start at 20% health.
+     * The fraction of max health which trees and gardener-produced robots start at.
      */
     float PLANTED_UNIT_STARTING_HEALTH_FRACTION = 0.2f;
 
@@ -99,7 +99,7 @@ public interface GameConstants {
     // ****** BULLETS ******************
     // *********************************
 
-    /** The amount that each team starts with */
+    /** The amount of bullets that each team starts with. */
     float BULLETS_INITIAL_AMOUNT = 300;
     
     /** The bullet income per turn (independent of number of archons).  */
@@ -112,54 +112,51 @@ public interface GameConstants {
     // ****** ATTACKING ****************
     // *********************************
 
-    /** The degrees at which the bullets are spread apart in a triad shot */
+    /** The degrees at which the bullets are spread apart in a triad shot. */
     float TRIAD_SPREAD_DEGREES = 20;
 
-    /** The degrees at which the bullets are spread apart in a pentad shot */
+    /** The degrees at which the bullets are spread apart in a pentad shot. */
     float PENTAD_SPREAD_DEGREES = 15;
 
-    /** The bullet cost to fire a single shot */
+    /** The bullet cost to fire a single shot. */
     float SINGLE_SHOT_COST = 1;
 
-    /** The bullet cost to fire a triad shot */
+    /** The bullet cost to fire a triad shot. */
     float TRIAD_SHOT_COST = 4;
 
-    /** The bullet cost to fire a pentad shot */
+    /** The bullet cost to fire a pentad shot. */
     float PENTAD_SHOT_COST = 6;
 
-    /** The distance from the outer edge of a robot bullets are spawned */
+    /** The distance from the outer edge of a robot bullets are spawned. */
     float BULLET_SPAWN_OFFSET = .05f;
 
-    /** The radius around a lumberjack affected by a strike() */
+    /** The radius around a lumberjack affected by a strike(). */
     float LUMBERJACK_STRIKE_RADIUS = 1;
     
     // *********************************
     // ****** MESSAGING ****************
     // *********************************
 
-    /** The size of the team-shared array for signaling*/
+    /** The size of the team-shared array for signaling. */
     int BROADCAST_MAX_CHANNELS = 1000;
 
     // *********************************
-    // ****** MISC. ********************
+    // ****** MISCELLANEOUS ************
     // *********************************
 
-    /** The number of bullets required for 1 victory point */
+    /** The price, in bullets, of 1 victory point. */
     int BULLET_EXCHANGE_RATE = 10;
 
     /**
-     * The distance between the edge of the robot spawning a robot/tree
-     * to spawned robot's/tree's edge
+     * The distance, as measured at its minimum value, between the bodies
+     * of a creator robot and the robot/tree it spawns.
      */
     float GENERAL_SPAWN_OFFSET = .01f;
 
-    /** The amount of health a tree gains when watered */
+    /** The amount of health a tree gains when watered. */
     float WATER_HEALTH_REGEN_RATE = BULLET_TREE_MAX_HEALTH/10f;
 
-    /** The amount of health a robot gains when repaired by an archon */
-    float REPAIR_HEALTH_REGEN_RATE = 1;
-
-    /** The max radius a robot can have */
+    /** The maximum radius a robot can have. */
     float MAX_ROBOT_RADIUS = 2;
     
     // *********************************

--- a/src/main/battlecode/common/MapLocation.java
+++ b/src/main/battlecode/common/MapLocation.java
@@ -140,8 +140,7 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      *
      * @param location the location to test
      * @param dist the distance for the location to be within
-     * @return true if the given location is within dist to this one,
-     *         or false if it isn't
+     * @return true if the given location is within dist to this one; false otherwise
      *
      * @battlecode.doc.costlymethod
      */
@@ -150,11 +149,10 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
     }
 
     /**
-     * Determines whether this location is within one stride of the given robot
+     * Determines whether this location is within one stride of the given robot.
      *
      * @param robot the robot to test
-     * @return true if this location is within one stride of the given robot,
-     *          false otherwise
+     * @return true if this location is within one stride of the given robot; false otherwise
      *
      * @battlecode.doc.costlymethod
      */
@@ -164,7 +162,7 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
 
     /**
      * Determines whether this location is within the sensor radius of the
-     * given robot
+     * given robot.
      *
      * @param robot the robot to test
      * @return true if this location is within the robot's sensor radius,
@@ -178,7 +176,7 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
 
     /**
      * Determines whether this location is within the bullet sight radius of the
-     * given robot
+     * given robot.
      *
      * @param robot the robot to test
      * @return true if this location is within robot's bullet sight radius,
@@ -342,7 +340,7 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
 
     /**
      * Returns a new MapLocation object translated from this location
-     * by a fixed amount
+     * by a fixed amount.
      *
      * @param dx the amount to translate in the x direction
      * @param dy the amount to translate in the y direction

--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -14,8 +14,8 @@ public strictfp interface RobotController {
     // *********************************
 
     /**
-     * Gets the number of rounds in the game. After this many rounds, if neither
-     * team has been destroyed, then the tiebreakers will be used.
+     * Returns the number of rounds in the game. After this many rounds, if neither
+     * team has been destroyed, tiebreakers will be used.
      *
      * @return the number of rounds in the game.
      *
@@ -27,7 +27,7 @@ public strictfp interface RobotController {
      * Returns the current round number, where round 0 is the first round of the
      * match.
      *
-     * @return the current round number, where 0 is the first round of the
+     * @return the current round number, where round 0 is the first round of the
      * match.
      *
      * @battlecode.doc.costlymethod
@@ -35,7 +35,7 @@ public strictfp interface RobotController {
     int getRoundNum();
 
     /**
-     * Gets the team's total bullet supply.
+     * Returns the team's total bullet supply.
      *
      * @return the team's total bullet supply.
      *
@@ -44,7 +44,7 @@ public strictfp interface RobotController {
     float getTeamBullets();
 
     /**
-     * Gets the team's total victory points.
+     * Returns the team's total victory points.
      *
      * @return the team's total victory points.
      *
@@ -75,12 +75,12 @@ public strictfp interface RobotController {
     /**
      * Returns a list of the INITIAL locations of the archons of a particular
      * team. The locations will be sorted by increasing x, with ties broken by
-     * increasing y. Will return an empty list if you query for NEUTRAL.
+     * increasing y. Will return an empty list if you query for {@code Team.NEUTRAL}.
      *
-     * @param t the team whose archons you want to query the initial locations
-     * for. Will return an empty list if you query for NEUTRAL.
+     * @param t the team for which you want to query the initial archon
+     * locations. Will return an empty list if you query for Team.NEUTRAL
      * @return a list of the INITIAL locations of the archons of that team, or
-     * an empty list for team NEUTRAL.
+     * an empty list for Team.NEUTRAL.
      *
      * @battlecode.doc.costlymethod
      */
@@ -91,7 +91,7 @@ public strictfp interface RobotController {
     // *********************************
 
     /**
-     * Use this method to access your ID.
+     * Returns the ID of this robot.
      *
      * @return the ID of this robot.
      *
@@ -100,7 +100,7 @@ public strictfp interface RobotController {
     int getID();
 
     /**
-     * Gets the Team of this robot.
+     * Returns this robot's Team.
      *
      * @return this robot's Team.
      *
@@ -109,7 +109,7 @@ public strictfp interface RobotController {
     Team getTeam();
 
     /**
-     * Gets this robot's type (SOLDIER, ARCHON, etc.).
+     * Returns this robot's type (SOLDIER, ARCHON, etc.).
      *
      * @return this robot's type.
      *
@@ -118,7 +118,7 @@ public strictfp interface RobotController {
     RobotType getType();
 
     /**
-     * Gets this robot's current location.
+     * Returns this robot's current location.
      *
      * @return this robot's current location.
      *
@@ -127,7 +127,7 @@ public strictfp interface RobotController {
     MapLocation getLocation();
 
     /**
-     * Gets this robot's current health.
+     * Returns this robot's current health.
      *
      * @return this robot's current health.
      *
@@ -161,8 +161,8 @@ public strictfp interface RobotController {
      * Senses whether a MapLocation is on the map. Will throw an exception if
      * the location is not currently within sensor range.
      *
-     * @param loc the location to check.
-     * @return true if the location is on the map, and false if it is not.
+     * @param loc the location to check
+     * @return true if the location is on the map; false otherwise.
      * @throws GameActionException if the location is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -173,9 +173,9 @@ public strictfp interface RobotController {
      * Senses whether a given circle is completely on the map. Will throw an exception if
      * the circle is not completely within sensor range.
      *
-     * @param center the center of the circle to check.
-     * @param radius the radius of the circle to check.
-     * @return true if the circle is completely on the map, false otherwise.
+     * @param center the center of the circle to check
+     * @param radius the radius of the circle to check
+     * @return true if the circle is completely on the map; false otherwise.
      * @throws GameActionException if any portion of the given circle is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -183,42 +183,42 @@ public strictfp interface RobotController {
     boolean onTheMap(MapLocation center, float radius) throws GameActionException;
 
     /**
-     * Returns true if the given location is within the robot's sensor range.
+     * Senses whether the given location is within the robot's sensor range.
      *
-     * @param loc the location to check.
-     * @return whether the given location is within the robot's sensor range.
+     * @param loc the location to check
+     * @return true the given location is within the robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSenseLocation(MapLocation loc);
 
     /**
-     * Returns true if any portion of the given circle is within the robot's sensor range.
+     * Senses whether any portion of the given circle is within the robot's sensor range.
      *
-     * @param center the center of the circle to check.
-     * @param radius the radius of the circle to check.
-     * @return whether a portion of the circle is within the robot's sensor range.
+     * @param center the center of the circle to check
+     * @param radius the radius of the circle to check
+     * @return true if a portion of the circle is within the robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSensePartOfCircle(MapLocation center, float radius);
 
     /**
-     * Returns true if all of the given circle is within the robot's sensor range.
+     * Senses whether all of the given circle is within the robot's sensor range.
      *
-     * @param center the center of the circle to check.
-     * @param radius the radius of the circle to check.
-     * @return whether all of the circle is within the robot's sensor range.
+     * @param center the center of the circle to check
+     * @param radius the radius of the circle to check
+     * @return true if all of the circle is within the robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSenseAllOfCircle(MapLocation center, float radius);
 
     /**
-     * Returns whether there is a robot or tree at the given location.
+     * Senses whether there is a robot or tree at the given location.
      *
-     * @param loc the location to check.
-     * @return whether there is a robot or tree at the given location.
+     * @param loc the location to check
+     * @return true if there is a robot or tree at the given location; false otherwise.
      * @throws GameActionException if the location is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -226,10 +226,10 @@ public strictfp interface RobotController {
     boolean isLocationOccupied(MapLocation loc) throws GameActionException;
 
     /**
-     * Returns whether there is a tree at the given location.
+     * Senses whether there is a tree at the given location.
      *
      * @param loc the location to check.
-     * @return whether there is a tree at the given location.
+     * @return true if there is a tree at the given location; false otherwise.
      * @throws GameActionException if the location is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -237,10 +237,10 @@ public strictfp interface RobotController {
     boolean isLocationOccupiedByTree(MapLocation loc) throws GameActionException;
 
     /**
-     * Returns whether there is a robot at the given location.
+     * Senses whether there is a robot at the given location.
      *
-     * @param loc the location to check.
-     * @return whether there is a robot at the given location.
+     * @param loc the location to check
+     * @return true if there is a robot at the given location; false otherwise.
      * @throws GameActionException if the location is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -248,11 +248,11 @@ public strictfp interface RobotController {
     boolean isLocationOccupiedByRobot(MapLocation loc) throws GameActionException;
 
     /**
-     * Returns whether there is any robot or tree within a given circle
+     * Senses whether there is any robot or tree within a given circle.
      *
-     * @param center the center of the circle to check.
-     * @param radius the radius of the circle to check.
-     * @return whether there is a robot or tree in the given circle.
+     * @param center the center of the circle to check
+     * @param radius the radius of the circle to check
+     * @return true if there is a robot or tree in the given circle; false otherwise.
      * @throws GameActionException if any portion of the given circle is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -260,12 +260,12 @@ public strictfp interface RobotController {
     boolean isCircleOccupied(MapLocation center, float radius) throws GameActionException;
 
     /**
-     * Returns whether there is any robot or tree within a given circle, ignoring this robot
-     * if it itself occupies the circle
+     * Senses whether there is any robot or tree within a given circle, ignoring this robot
+     * if it itself occupies the circle.
      *
-     * @param center the center of the circle to check.
-     * @param radius the radius of the circle to check.
-     * @return whether there is a robot or tree in the given circle.
+     * @param center the center of the circle to check
+     * @param radius the radius of the circle to check
+     * @return true if there is a robot or tree in the given circle; false otherwise.
      * @throws GameActionException if any portion of the given circle is not within sensor range.
      *
      * @battlecode.doc.costlymethod
@@ -273,10 +273,10 @@ public strictfp interface RobotController {
     boolean isCircleOccupiedExceptByThisRobot(MapLocation center, float radius) throws GameActionException;
 
     /**
-     * Returns the tree at the given location, or null if there is no tree
+     * Senses the tree at the given location, or null if there is no tree
      * there.
      *
-     * @param loc the location to check.
+     * @param loc the location to check
      * @return the tree at the given location.
      * @throws GameActionException if the location is not within sensor range.
      *
@@ -285,10 +285,10 @@ public strictfp interface RobotController {
     TreeInfo senseTreeAtLocation(MapLocation loc) throws GameActionException;
 
     /**
-     * Returns the robot at the given location, or null if there is no robot
+     * Senses the robot at the given location, or null if there is no robot
      * there.
      *
-     * @param loc the location to check.
+     * @param loc the location to check
      * @return the robot at the given location.
      * @throws GameActionException if the location is not within sensor range.
      *
@@ -297,33 +297,33 @@ public strictfp interface RobotController {
     RobotInfo senseRobotAtLocation(MapLocation loc) throws GameActionException;
 
     /**
-     * Returns true if the given tree exists and any part of the given tree is
+     * Tests whether the given tree exists and any part of the given tree is
      * within this robot's sensor range.
      *
-     * @param id the ID of the tree to query.
-     * @return whether the given tree is within this robot's sensor range.
+     * @param id the ID of the tree to query
+     * @return true if the given tree is within this robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSenseTree(int id);
 
     /**
-     * Returns true if the given robot exists and any part of the given robot is
+     * Tests whether the given robot exists and any part of the given robot is
      * within this robot's sensor range.
      *
-     * @param id the ID of the robot to query.
-     * @return whether the given robot is within this robot's sensor range.
+     * @param id the ID of the robot to query
+     * @return true if the given robot is within this robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSenseRobot(int id);
 
     /**
-     * Returns true if the given bullet exists and if it is within this robot's
+     * Tests the given bullet exists and it is within this robot's
      * sensor range.
      *
-     * @param id the ID of the bullet to query.
-     * @return whether the given bullet is within this robot's sensor range.
+     * @param id the ID of the bullet to query
+     * @return true if the given bullet is within this robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
@@ -332,7 +332,7 @@ public strictfp interface RobotController {
     /**
      * Senses information about a particular tree given its ID.
      *
-     * @param id the ID of the tree to query.
+     * @param id the ID of the tree to query
      * @return a TreeInfo object for the sensed tree.
      * @throws GameActionException if the tree cannot be sensed (for example,
      * if it doesn't exist or is out of sight range).
@@ -344,7 +344,7 @@ public strictfp interface RobotController {
     /**
      * Senses information about a particular robot given its ID.
      *
-     * @param id the ID of the robot to query.
+     * @param id the ID of the robot to query
      * @return a RobotInfo object for the sensed robot.
      * @throws GameActionException if the robot cannot be sensed (for example,
      * if it doesn't exist or is out of sight range).
@@ -356,7 +356,7 @@ public strictfp interface RobotController {
     /**
      * Senses information about a particular bullet given its ID.
      *
-     * @param id the ID of the bullet to query.
+     * @param id the ID of the bullet to query
      * @return a BulletInfo object for the sensed bullet.
      * @throws GameActionException if the bullet cannot be sensed (for example,
      * if it doesn't exist or is out of sight range).
@@ -380,7 +380,7 @@ public strictfp interface RobotController {
      * robot.
      *
      * @param radius return robots this distance away from the center of
-     * this robot. If -1 is passed, all robots within sense radius are returned.
+     * this robot. If -1 is passed, all robots within sense radius are returned
      * @return array of RobotInfo objects of all the robots you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -392,9 +392,9 @@ public strictfp interface RobotController {
      * radius of this robot.
      *
      * @param radius return robots this distance away from the center of
-     * this robot. If -1 is passed, all robots within sense radius are returned.
+     * this robot. If -1 is passed, all robots within sense radius are returned
      * @param team filter game objects by the given team. If null is passed,
-     * robots from any team are returned.
+     * robots from any team are returned
      * @return array of RobotInfo objects of all the robots you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -405,11 +405,11 @@ public strictfp interface RobotController {
      * Returns all robots of a given team that can be sensed within a certain
      * radius of a specified location.
      *
-     * @param center center of the given search radius.
+     * @param center center of the given search radius
      * @param radius return robots this distance away from the given center
-     * location. If -1 is passed, all robots within sense radius are returned.
+     * location. If -1 is passed, all robots within sense radius are returned
      * @param team filter game objects by the given team. If null is passed,
-     * objects from all teams are returned.
+     * objects from all teams are returned
      * @return array of RobotInfo objects of the robots you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -431,7 +431,7 @@ public strictfp interface RobotController {
      * robot.
      *
      * @param radius return trees this distance away from the center of
-     * this robot. If -1 is passed, all trees within sense radius are returned.
+     * this robot. If -1 is passed, all trees within sense radius are returned
      * @return array of TreeInfo objects of all the trees you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -443,9 +443,9 @@ public strictfp interface RobotController {
      * radius of this robot.
      *
      * @param radius return trees this distance away from the center of
-     * this robot. If -1 is passed, all trees within sense radius are returned.
+     * this robot. If -1 is passed, all trees within sense radius are returned
      * @param team filter game objects by the given team. If null is passed,
-     * robots from any team are returned.
+     * robots from any team are returned
      * @return array of TreeInfo objects of all the trees you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -456,11 +456,11 @@ public strictfp interface RobotController {
      * Returns all trees of a given team that can be sensed within a certain
      * radius of a specified location.
      *
-     * @param center center of the given search radius.
+     * @param center center of the given search radius
      * @param radius return trees this distance away from given center
-     * location. If -1 is passed, all trees within sense radius are returned.
+     * location. If -1 is passed, all trees within sense radius are returned
      * @param team filter game objects by the given team. If null is passed,
-     * objects from all teams are returned.
+     * objects from all teams are returned
      * @return array of TreeInfo objects of the trees you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -482,7 +482,7 @@ public strictfp interface RobotController {
      * robot.
      *
      * @param radius return bullets this distance away from the center of
-     * this robot. If -1 is passed, bullets from the whole map are returned.
+     * this robot. If -1 is passed, bullets from the whole map are returned
      * @return array of BulletInfo objects of all the bullets you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -493,9 +493,9 @@ public strictfp interface RobotController {
      * Returns all bullets that can be sensed within a certain
      * radius of a specified location.
      *
-     * @param center center of the given search radius.
+     * @param center center of the given search radius
      * @param radius return bullets this distance away from the given center
-     * location. If -1 is passed, all bullets within bullet sense radius are returned..
+     * location. If -1 is passed, all bullets within bullet sense radius are returned
      * @return array of TreeInfo objects of the bullets you sensed.
      *
      * @battlecode.doc.costlymethod
@@ -504,7 +504,7 @@ public strictfp interface RobotController {
 
     /**
      * Returns an array of all the locations of the robots that have
-     * broadcasted in the last round (unconstrained by sensor range or distance)
+     * broadcasted in the last round (unconstrained by sensor range or distance).
      *
      * @return an array of all the locations of the robots that have
      * broadcasted in the last round.
@@ -518,88 +518,86 @@ public strictfp interface RobotController {
     // ***********************************
     
     /**
-     * Returns true if the robot has moved this turn.
+     * Returns whether the robot has moved this turn.
      * 
-     * @return true if the robot has moved this turn.
+     * @return true if the robot has moved this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean hasMoved();
     
     /**
-     * Returns true if the robot has attacked this turn.
+     * Returns whether the robot has attacked this turn.
      * 
-     * @return true if the robot has attacked this turn.
+     * @return true if the robot has attacked this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean hasAttacked();
     
     /**
-     * Returns true if the robot's build cooldown has expired.
+     * Returns whether the robot's build cooldown has expired.
      * 
-     * @return true if the robot's build cooldown has expired.
+     * @return true if the robot's build cooldown has expired; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean isBuildReady();
 
     /**
-     * Tells whether this robot can move one stride in the given direction,
+     * Tests whether this robot can move one stride in the given direction,
      * without taking into account if they have already moved. Takes into account only
      * the positions of trees, positions of other robots, and the edge of the
      * game map. Does not take into account whether this robot is currently
-     * active.  Note that one stride is equivalent to StrideRadius.
+     * active. Note that one stride is equivalent to this robot's {@code strideRadius}.
      *
-     * @param dir the direction to move in.
-     * @return true if there is nothing preventing this robot from moving one
-     * stride in the given direction; false otherwise (does not account for
-     * core delay).
+     * @param dir the direction to move in
+     * @return true if there is no external obstruction to prevent this robot
+     * from moving one stride in the given direction; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canMove(Direction dir);
 
     /**
-     * Tells whether this robot can move distance in the given direction,
-     * without taking into account if they have already moved. Takes into
+     * Tests whether this robot can move {@code distance} units in the given
+     * direction, without taking into account if they have already moved. Takes into
      * account only the positions of trees, positions of other robots, and the
      * edge of the game map. Does not take into account whether this robot is
-     * currently active. Note that one stride is equivalent to StrideRadius.
+     * currently active. Note that one stride is equivalent to this robot's
+     * {@code strideRadius}.
      *
-     *
-     * @param dir the direction to move in.
+     * @param dir the direction to move in
      * @param distance the distance of a move you wish to check. Must be
-     * from 0 to RobotType.strideRadius (inclusive).
-     * @return true if there is nothing preventing this robot from moving distance
-     * in the given direction; false otherwise (does not account for
-     * the robot having already moved that turn).
+     * in [0, RobotType.strideRadius]
+     * @return true if there is no external obstruction to prevent this robot
+     * from moving distance in the given direction; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canMove(Direction dir, float distance);
     
     /**
-     * Tells whether this robot can move to the target MapLocation. If the location
-     * is outside the robot's StrideRadius, the location is rescaled to be at the
-     * StrideRadius. Takes into account only the positions of rees, positions of
-     * other robots, and the edge of the game map. Does not take into account whether
-     * this robot is currently active.
+     * Tests whether this robot can move to the target {@code MapLocation}. If
+     * the location is outside the robot's {@code strideRadius}, the location
+     * is rescaled to be at the {@code strideRadius}. Takes into account only
+     * the positions of trees, other robots, and the edge of the game map. Does
+     * not take into account whether this robot is currently active.
      * 
-     * @param center the MapLocation to move to.
-     * @return true if there is nothing preventing this robot from moving to this
-     * MapLocation (or in the direction of this MapLocation if it is too far);
-     * false otherwise (does not account for the robot having already moved that turn).
+     * @param center the MapLocation to move to
+     * @return true if there is no external obstruction to prevent this robot
+     * from moving to this MapLocation (or in the direction of this MapLocation
+     * if it is too far); false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canMove(MapLocation center);
     
     /**
-     * Moves one stride in the given direction. One stride is given by the robot's
-     * stride radius (RobotType.strideRadius).
+     * Moves one stride in the given direction. Note that one stride is equivalent
+     * to this robot's {@code strideRadius}.
      *
-     * @param dir the direction to move in.
+     * @param dir the direction to move in
      * @throws GameActionException if the robot cannot move one stride in this
      * direction, such as already moved that turn, the target location being
      * off the map, and the target destination being occupied with either
@@ -610,10 +608,11 @@ public strictfp interface RobotController {
     void move(Direction dir) throws GameActionException;
 
     /**
-     * Moves distance in the given direction.
+     * Moves distance in the given direction. If the distance exceeds the robot's
+     * {@code strideRadius}, it is rescaled to {@code strideRadius}.
      *
-     * @param dir the direction to move in.
-     * @param distance the distance to move in that direction.
+     * @param dir the direction to move in
+     * @param distance the distance to move in that direction
      * @throws GameActionException if the robot cannot move distance in this
      * direction, such as already moved that turn, the target location being
      * off the map, and the target destination being occupied with either
@@ -625,7 +624,7 @@ public strictfp interface RobotController {
     
     /**
      * Moves to the target MapLocation. If the target location is outside the robot's
-     * StrideRadius, it is rescaled to be one StrideRadius away.
+     * {@code strideRadius}, it is rescaled to be {@code strideRadius} away.
      * 
      * @param center the MapLocation to move to (or toward)
      * @throws GameActionException if the robot can not move to the target MapLocation,
@@ -641,18 +640,19 @@ public strictfp interface RobotController {
     // ***********************************
 
     /**
-     * Returns true if a robot is able to strike this turn. This takes into accout
+     * Tests whether a robot is able to strike this turn. This takes into accout
      * the robot's type, and if the robot has attacked this turn.
      *
-     * @return True if the robot is able to strike this turn.
+     * @return true if the robot is able to strike this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canStrike();
 
     /**
-     * Strikes and deals damage to all other robots and trees within one stride of
-     * this robot. Note that only Lumberjacks can perform this function.
+     * Strikes and deals damage to all other robots and trees within
+     * @{code LUMBERJACK_STRIKE_RADIUS} of this robot. Note that only Lumberjacks
+     * can perform this function.
      *
      * @throws GameActionException if the robot is not of type LUMBERJACK or
      * cannot attack due to having already attacked that turn.
@@ -662,36 +662,39 @@ public strictfp interface RobotController {
     void strike() throws GameActionException;
 
     /**
-     * Tells whether there is enough bullets in your bullet supply to
-     * fire a single shot and if the robot is of an appropriate type and
-     * if the robot has not attacked in the current turn.
+     * Tests whether there are enough bullets in your bullet supply to
+     * fire a single shot, the robot is of an appropriate type, and the
+     * robot has not attacked in the current turn.
      *
      * @return true if there are enough bullets in the bullet supply,
-     * this robot is of an appropriate type, and the robot hasn't attacked this turn.
+     * this robot is of an appropriate type, and the robot hasn't attacked
+     * this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canFireSingleShot();
 
     /**
-     * Tells whether there is enough bullets in your bullet supply to
-     * fire a triad shot and if the robot is of an appropriate type and
-     * if the robot has not attacked in the current turn.
+     * Tests whether there are enough bullets in your bullet supply to
+     * fire a triad shot, the robot is of an appropriate type, and the
+     * robot has not attacked in the current turn.
      *
      * @return true if there are enough bullets in the bullet supply,
-     * this robot is of an appropriate type, and the robot hasn't attacked this turn.
+     * this robot is of an appropriate type, and the robot hasn't attacked
+     * this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canFireTriadShot();
 
     /**
-     * Tells whether there is enough bullets in your bullet supply to
-     * fire a pentad shot and if the robot is of an appropriate type and
-     * if the robot has not attacked in the current turn.
+     * Tests whether there is enough bullets in your bullet supply to
+     * fire a pentad shot, the robot is of an appropriate type, and the
+     * robot has not attacked in the current turn.
      *
      * @return true if there are enough bullets in the bullet supply,
-     * this robot is of an appropriate type, and the robot hasn't attacked this turn.
+     * this robot is of an appropriate type, and the robot hasn't attacked
+     * this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
@@ -699,10 +702,10 @@ public strictfp interface RobotController {
 
     /**
      * Fires a single bullet in the direction dir at the cost of
-     * GameConstants.SINGLE_SHOT_COST from your team's bullet supply. The speed
+     * {@code SINGLE_SHOT_COST} from your team's bullet supply. The speed
      * and damage of the bullet is determined from the type of this robot.
      *
-     * @param dir the direction you wish to fire the bullet.
+     * @param dir the direction you wish to fire the bullet
      * @throws GameActionException if this robot is not of a type that can
      * fire single shots (ARCHON, GARDENER, etc.), cannot attack due to having
      * already attacked, or for having insufficient bullets in the bullet supply.
@@ -713,12 +716,12 @@ public strictfp interface RobotController {
 
     /**
      * Fires a three bullets with the center bullet in the direction dir and
-     * with a spread of GameConstants.TRIAD_SPREAD_DEGREES degrees for the other
-     * bullets.  This function costs GameConstants.TRIAD_SHOT_COST bullets from
+     * with a spread of {@code TRIAD_SPREAD_DEGREES} degrees for the other
+     * bullets.  This function costs {@code TRIAD_SHOT_COST} bullets from
      * your team's supply. The speed and damage of the bullets is determined
      * from the type of this robot.
      *
-     * @param dir the direction you wish to fire the center bullet.
+     * @param dir the direction you wish to fire the center bullet
      * @throws GameActionException if this robot is not of a type that can
      * fire triad shots (ARCHON, GARDENER, etc.), cannot attack due to having
      * already attacked, or for having insufficient bullets in the bullet supply.
@@ -729,12 +732,12 @@ public strictfp interface RobotController {
 
     /**
      * Fires a five bullets with the center bullet in the direction dir and
-     * with a spread of GameConstants.PENTAD_SPREAD_DEGREES degrees for the other
-     * bullets.  This function costs GameConstants.PENTAD_SHOT_COST bullets from
+     * with a spread of {@code PENTAD_SPREAD_DEGREES} degrees for the other
+     * bullets.  This function costs {@code PENTAD_SHOT_COST} bullets from
      * your team's supply. The speed and damage of the bullets is determined
      * from the type of this robot.
      *
-     * @param dir the direction you wish to fire the center bullet.
+     * @param dir the direction you wish to fire the center bullet
      * @throws GameActionException if this robot is not of a type that can
      * fire pentad shots (ARCHON, GARDENER, etc.), cannot attack due to having
      * already attacked, or for having insufficient bullets in the bullet supply.
@@ -748,47 +751,47 @@ public strictfp interface RobotController {
     // ***********************************
 
     /**
-     * Tells whether the robot can chop, has not already attacked this turn,
+     * Tests whether the robot can chop, has not already attacked this turn,
      * and will hit an in-range tree at the given location.
      *
      * @param loc The location of the tree to test
-     * @return True if the tree can be chopped this turn
+     * @return true if the tree can be chopped this turn; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canChop(MapLocation loc);
 
     /**
-     * Tells whether the robot can chop, has not already attacked this turn,
-     * and "id" corresponds to an in-range tree.
+     * Tests whether the robot can chop, has not already attacked this turn,
+     * and {@code id} corresponds to an in-range tree.
      *
      * @param id The id of the tree to chop
-     * @return True of the tree can be chopped by this robot
+     * @return true of the tree can be chopped by this robot; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canChop(int id);
 
     /**
-     * Chops the target tree at location loc. This action counts as an attack.
+     * Chops the target tree at location {@code loc}. This action counts as an attack.
      *
      * @param loc the location of the tree you wish to chop, does not
      * have to be the center of the tree
      * @throws GameActionException if the given location does not contain
-     * a tree, if the tree (not location) is not within one stride of this
-     * robot, or cannot perform action due to having already moved.
+     * a tree, the specified tree is not within one stride of this
+     * robot, or this robot cannot perform an action due to having already moved.
      *
      * @battlecode.doc.costlymethod
      */
     void chop(MapLocation loc) throws GameActionException;
 
     /**
-     * Chops the target tree at location loc. This action counts as an attack.
+     * Chops the target tree at location {@code loc}. This action counts as an attack.
      *
-     * @param id the id of the tree you wish to chop.
+     * @param id the id of the tree you wish to chop
      * @throws GameActionException if there isn't a tree with the given id,
-     * if the tree (not location) is not within one stride of this robot,
-     * or cannot perform action due to having already moved.
+     * the specified tree is not within one stride of this robot,
+     * or this robot cannot perform an action due to having already moved.
      *
      * @battlecode.doc.costlymethod
      */

--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -578,7 +578,7 @@ public strictfp interface RobotController {
     boolean canMove(Direction dir, float distance);
     
     /**
-     * Tests whether this robot can move to the target {@code MapLocation}. If
+     * Tests whether this robot can move to the target MapLocation. If
      * the location is outside the robot's {@code strideRadius}, the location
      * is rescaled to be at the {@code strideRadius}. Takes into account only
      * the positions of trees, other robots, and the edge of the game map. Does
@@ -651,7 +651,7 @@ public strictfp interface RobotController {
 
     /**
      * Strikes and deals damage to all other robots and trees within
-     * @{code LUMBERJACK_STRIKE_RADIUS} of this robot. Note that only Lumberjacks
+     * {@link GameConstants#LUMBERJACK_STRIKE_RADIUS} of this robot. Note that only Lumberjacks
      * can perform this function.
      *
      * @throws GameActionException if the robot is not of type LUMBERJACK or
@@ -702,7 +702,7 @@ public strictfp interface RobotController {
 
     /**
      * Fires a single bullet in the direction dir at the cost of
-     * {@code SINGLE_SHOT_COST} from your team's bullet supply. The speed
+     * {@link GameConstants#SINGLE_SHOT_COST} from your team's bullet supply. The speed
      * and damage of the bullet is determined from the type of this robot.
      *
      * @param dir the direction you wish to fire the bullet
@@ -716,8 +716,8 @@ public strictfp interface RobotController {
 
     /**
      * Fires a three bullets with the center bullet in the direction dir and
-     * with a spread of {@code TRIAD_SPREAD_DEGREES} degrees for the other
-     * bullets.  This function costs {@code TRIAD_SHOT_COST} bullets from
+     * with a spread of {@link GameConstants#TRIAD_SPREAD_DEGREES} degrees for the other
+     * bullets.  This function costs {@link GameConstants#TRIAD_SHOT_COST} bullets from
      * your team's supply. The speed and damage of the bullets is determined
      * from the type of this robot.
      *
@@ -732,8 +732,8 @@ public strictfp interface RobotController {
 
     /**
      * Fires a five bullets with the center bullet in the direction dir and
-     * with a spread of {@code PENTAD_SPREAD_DEGREES} degrees for the other
-     * bullets.  This function costs {@code PENTAD_SHOT_COST} bullets from
+     * with a spread of {@link GameConstants#PENTAD_SPREAD_DEGREES} degrees for the other
+     * bullets.  This function costs {@link GameConstants#PENTAD_SHOT_COST} bullets from
      * your team's supply. The speed and damage of the bullets is determined
      * from the type of this robot.
      *
@@ -891,7 +891,7 @@ public strictfp interface RobotController {
 
     /**
      * Waters the target tree with the given ID, restoring
-     * {@code WATER_HEALTH_REGEN_RATE} health to the tree.
+     * {@link GameConstants#WATER_HEALTH_REGEN_RATE} health to the tree.
      * Robots can only water once per turn and only with robots
      * of type GARDENER.
      *

--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -751,200 +751,202 @@ public strictfp interface RobotController {
     // ***********************************
 
     /**
-     * Tests whether the robot can chop, has not already attacked this turn,
-     * and will hit an in-range tree at the given location.
+     * Tests whether the robot can chop a tree at the given location. Checks robot
+     * stride radius, the robot's type, if a tree exists, and if the robot hasn't
+     * attacked this turn.
      *
-     * @param loc The location of the tree to test
-     * @return true if the tree can be chopped this turn; false otherwise.
+     * @param loc The location of the tree to chop
+     * @return true if this robot can chop the tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canChop(MapLocation loc);
 
     /**
-     * Tests whether the robot can chop, has not already attacked this turn,
-     * and {@code id} corresponds to an in-range tree.
+     * Tests whether the robot can chop a tree with the given ID. Checks robot
+     * stride radius, the robot's type, if a tree exists, and if the robot hasn't
+     * attacked this turn.
      *
-     * @param id The id of the tree to chop
-     * @return true of the tree can be chopped by this robot; false otherwise.
+     * @param id The ID of the tree to chop
+     * @return true if this robot can chop the tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canChop(int id);
 
     /**
-     * Chops the target tree at location {@code loc}. This action counts as an attack.
+     * Chops the tree at the given location. This action counts as an attack.
      *
-     * @param loc the location of the tree you wish to chop, does not
-     * have to be the center of the tree
+     * @param loc the location of the tree to chop
      * @throws GameActionException if the given location does not contain
-     * a tree, the specified tree is not within one stride of this
-     * robot, or this robot cannot perform an action due to having already moved.
+     * a tree, the specified tree is not within one stride of this robot,
+     * this robot is not of type LUMBERJACK, or this robot has already attacked
+     * this turn.
      *
      * @battlecode.doc.costlymethod
      */
     void chop(MapLocation loc) throws GameActionException;
 
     /**
-     * Chops the target tree at location {@code loc}. This action counts as an attack.
+     * Chops the tree with the given ID. This action counts as an attack.
      *
-     * @param id the id of the tree you wish to chop
+     * @param id the ID of the tree you wish to chop
      * @throws GameActionException if there isn't a tree with the given id,
-     * the specified tree is not within one stride of this robot,
-     * or this robot cannot perform an action due to having already moved.
+     * the specified tree is not within one stride of this robot, this robot
+     * is not of type LUMBERJACK, or this robot has already attacked this turn.
      *
      * @battlecode.doc.costlymethod
      */
     void chop(int id) throws GameActionException;
 
     /**
-     * Tells if this robot can shake the tree at the given location. Checks robot
+     * Tests whether this robot can shake a tree at the given location. Checks robot
      * stride radius, if a tree exists, and if the robot hasn't shaken this turn.
      *
-     * @param loc The location of a tree to shake.
-     * @return true if this tree can be shaken by this robot this turn.
+     * @param loc The location of the tree to shake
+     * @return true if this robot can shake the tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canShake(MapLocation loc);
 
     /**
-     * Tells if a robot can shake a tree with this id. Checks robot stride radius,
-     * if a tree exists, and if the robot hasn't shaken this turn.
+     * Tests whether this robot can shake a tree with the given ID. Checks robot
+     * stride radius, if a tree exists, and if the robot hasn't shaken this turn.
      *
-     * @param id The ID of a tree to shake.
-     * @return true if this tree can be shaken by this robot this turn.
+     * @param id The ID of the tree to shake
+     * @return true if this robot can shake the tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canShake(int id);
 
     /**
-     * Shakes the target tree at location loc for all the bullets held within
+     * Shakes the tree at the given location for all the bullets held within
      * the tree; these bullets will be added to your team's bullet supply.
      * Robots can only shake once per turn.
      *
-     * @param loc the location of the tree you wish to shake, does not
-     * have to be the center of the tree
+     * @param loc the location of the tree to shake
      * @throws GameActionException if the given location does not contain
      * a tree, if the tree (not location) is not within one stride of this
-     * robot, or if this robot has already shook a tree this turn
+     * robot, or if this robot has already shaken a tree this turn.
      *
      * @battlecode.doc.costlymethod
      */
     void shake(MapLocation loc) throws GameActionException;
 
     /**
-     * Shakes the target tree at location loc for all the bullets held within
+     * Shakes the tree with the given ID for all the bullets held within
      * the tree; these bullets will be added to your team's bullet supply.
      * Robots can only shake once per turn.
      *
-     * @param id the id of the tree you wish to shake.
+     * @param id the ID of the tree to shake
      * @throws GameActionException if there isn't a tree with the given id,
      * if the tree (not location) is not within one stride of this robot,
-     * or if this robot has already shook a tree this turn
+     * or if this robot has already shaken a tree this turn
      *
      * @battlecode.doc.costlymethod
      */
     void shake(int id) throws GameActionException;
 
     /**
-     * Determines whether the robot can water a tree. Takes into accout the
-     * robot's type, if it's already watered this turn, and if a valid
-     * tree at this location exists within range.
+     * Tests whether this robot can water a tree at the given location. Checks robot
+     * stride radius, the robot's type, if a tree exists, and if the robot hasn't
+     * watered this turn.
      *
-     * @param loc The location of a tree to check.
-     * @return true if this robot can water a tree, false otherwise.
+     * @param loc The location of the tree to water
+     * @return true if this robot can water the tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canWater(MapLocation loc);
 
     /**
-     * Determines whether the robot can water a tree. Takes into accout the
-     * robot's type, if it's already watered this turn, and if a valid
-     * tree with this id exists within range.
+     * Tests whether this robot can water a tree with the given ID. Checks robot
+     * stride radius, the robot's type, if a tree exists, and if the robot hasn't
+     * watered this turn.
      *
-     * @param id The id of a tree to check.
-     * @return true if this robot can water a tree, false otherwise.
+     * @param id The ID of a tree to check.
+     * @return true if this robot can water a tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canWater(int id);
 
     /**
-     * Waters the target tree at location loc, healing
-     * GameConstants.WATER_HEALTH_REGEN_RATE health to the tree.
+     * Waters the target tree at the given location, restoring
+     * {@code WATER_HEALTH_REGEN_RATE} health to the tree.
      * Robots can only water once per turn and only with robots
      * of type GARDENER.
      *
-     * @param loc the location of the tree you wish to water, does not
-     * have to be the center of the tree
+     * @param loc the location of the tree you wish to water
      * @throws GameActionException if the given location does not contain
-     * a tree, if the tree (not location) is not within one stride of this
-     * robot, or this robot is not of type GARDENER
+     * a tree, the tree is not within one stride of this robot,
+     * this robot is not of type GARDENER, or this robot has already
+     * watered a tree.
      *
      * @battlecode.doc.costlymethod
      */
     void water(MapLocation loc) throws GameActionException;
 
     /**
-     * Waters the target tree at location loc, healing
-     * GameConstants.WATER_HEALTH_REGEN_RATE health to the tree.
+     * Waters the target tree with the given ID, restoring
+     * {@code WATER_HEALTH_REGEN_RATE} health to the tree.
      * Robots can only water once per turn and only with robots
      * of type GARDENER.
      *
-     * @param id the id of the tree you wish to water.
+     * @param id the ID of the tree you wish to water.
      * @throws GameActionException if there isn't a tree with the given id,
-     * if the tree (not location) is not within one stride of this robot,
-     * or this robot is not of type GARDENER
+     * the tree is not within one stride of this robot,
+     * this robot is not of type GARDENER, or this robot has already
+     * watered a tree.
      *
      * @battlecode.doc.costlymethod
      */
     void water(int id) throws GameActionException;
 
     /**
-     * Determines whether or not this robot can water a tree, taking into
+     * Tests whether this robot can water a tree, taking into
      * account how many times this robot has watered this turn and this
-     * robot's type
+     * robot's type.
      *
-     * @return true if this robot can water a tree, false otherwise.
+     * @return true if this robot can water a tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canWater();
 
     /**
-     * Determines whether or not this robot can shake a tree, taking into
-     * account how many times this robot has shook this turn.
+     * Tests whether this robot can shake a tree, taking into
+     * account how many times this robot has shaken this turn.
      *
-     * @return true if this robot can shake a tree, false otherwise.
+     * @return true if this robot can shake a tree; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canShake();
 
     /**
-     * Determines whether or not there is a tree at location loc and, if so,
+     * Tests whether there is a tree at the given location and, if so,
      * if the tree is within one stride of this robot and can therefore be
      * interacted with through chop(), shake(), or water().
      *
      * @param loc the location you wish to test
      * @return true if there is a tree located at loc and if said tree is
-     * within one stride of this robot
+     * within one stride of this robot.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canInteractWithTree(MapLocation loc);
 
     /**
-     * Determines whether or not there is a tree with the given id and, if so,
+     * Tests whether there is a tree with the given ID and, if so,
      * if the tree is within one stride of this robot and can therefore be
      * interacted with through chop(), shake(), or water().
      *
-     * @param id the id of the tree you wish to test
-     * @return true if there is a tree with the given id and if siad tree is
-     * within a stride of this robot
+     * @param id the ID of the tree you wish to test
+     * @return true if there is a tree with id and if said tree is
+     * within one stride of this robot.
      *
      * @battlecode.doc.costlymethod
      */
@@ -958,8 +960,8 @@ public strictfp interface RobotController {
      * Broadcasts a message to the team-shared array at index channel.
      * The data is not written until the end of the robot's turn.
      *
-     * @param channel - the index to write to, from 0 to <code>BROADCAST_MAX_CHANNELS</code>
-     * @param data - one int's worth of data to write
+     * @param channel the index to write to, from 0 to <code>BROADCAST_MAX_CHANNELS</code>
+     * @param data one int of data to write
      * @throws GameActionException if the channel is invalid
      *
      * @battlecode.doc.costlymethod
@@ -970,7 +972,7 @@ public strictfp interface RobotController {
      * Retrieves the message stored in the team-shared array at index channel.
      *
      * @param channel the index to query, from 0 to <code>BROADCAST_MAX_CHANNELS</code>
-     * @return data currently stored on the channel
+     * @return the data currently stored on the channel.
      * @throws GameActionException  if the channel is invalid
      *
      * @battlecode.doc.costlymethod
@@ -982,34 +984,34 @@ public strictfp interface RobotController {
     // ***********************************
 
     /**
-     * Returns whether you have the bullets and dependencies to build the given
+     * Tests whether you have the bullets and dependencies to build the given
      * robot, and this robot is a valid builder for the target robot.
      *
-     * @param type the type to build.
-     * @return whether the requirements to build are met.
+     * @param type the type of robot to build
+     * @return true if the requirements to build the given robot are met; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean hasRobotBuildRequirements(RobotType type);
 
     /**
-     * Returns whether you have the bullets and dependencies to build a
+     * Tests whether you have the bullets and dependencies to build a
      * bullet tree, and this robot is a valid builder for a bullet tree.
      *
-     * @return whether the requirements to build are met.
+     * @return true if the requirements to plant a tree are met; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean hasTreeBuildRequirements();
 
     /**
-     * Returns whether the robot can build a robot of the given type in the
-     * given direction. Checks dependencies, cooldown turns remaining,
-     * bullet costs, whether the robot can build, and that the given direction is
+     * Tests whether the robot can build a robot of the given type in the
+     * given direction. Checks cooldown turns remaining, bullet costs,
+     * whether the robot can build, and that the given direction is
      * not blocked.
      *
-     * @param dir the direction to build in.
-     * @param type the robot type to build.
+     * @param dir the direction to build in
+     * @param type the type of robot to build
      * @return whether it is possible to build a robot of the given type in the
      * given direction.
      *
@@ -1018,25 +1020,24 @@ public strictfp interface RobotController {
     boolean canBuildRobot(RobotType type, Direction dir);
 
     /**
-     * Plants/Builds a robot of the given type in the given direction.
+     * Builds a robot of the given type in the given direction.
      *
-     * @param dir the direction to spawn the unit.
+     * @param dir the direction to spawn the unit
      * @param type the type of robot to build
-     * @throws GameActionException if the build is bad: if you don't have enough
-     * bullets, if you have coreDelay, if the direction is not a good build
-     * direction, or if you are not of type GARDENER.
+     * @throws GameActionException if you don't have enough bullets, if
+     * the robot is still in build cooldown, if the direction is not a
+     * good build direction, or if this robot is not of an appropriate type.
      *
      * @battlecode.doc.costlymethod
      */
     void buildRobot(RobotType type, Direction dir) throws GameActionException;
 
     /**
-     * Returns whether the robot can build a bullet tree in the given direction.
-     * Checks dependencies, cooldown turns remaining, bullet costs,
-     * whether the robot can build, and that the given direction is
-     * not blocked.
+     * Tests whether the robot can build a bullet tree in the given direction.
+     * Checks cooldown turns remaining, bullet costs, whether the robot can
+     * plant, and that the given direction is not blocked
      *
-     * @param dir the direction to build in.
+     * @param dir the direction to build in
      * @return whether it is possible to build a bullet tree in the
      * given direction.
      *
@@ -1045,24 +1046,23 @@ public strictfp interface RobotController {
     boolean canPlantTree(Direction dir);
 
     /**
-     * Plants a bullet tree in the given direction. This is a core action.
+     * Plants a bullet tree in the given direction.
      *
-     * @param dir the direction to plant the bullet tree.
-     * @throws GameActionException if the build is bad: if you don't have enough
-     * bullets, if you have coreDelay, if the direction is not a good build
-     * direction, or if you are not of type GARDENER.
+     * @param dir the direction to plant the bullet tree
+     * @throws GameActionException if you don't have enough bullets, if
+     * the robot is still in build cooldown, if the direction is not a good build
+     * direction, or if this robot is not of an appropriate type.
      *
      * @battlecode.doc.costlymethod
      */
     void plantTree(Direction dir) throws  GameActionException;
 
     /**
-     * Returns whether the robot can hire a gardener in the given direction.
-     * Checks dependencies, cooldown turns remaining, bullet costs,
-     * whether the robot can build, and that the given direction is
-     * not blocked.
+     * Tests whether the robot can hire a Gardener in the given direction.
+     * Checks cooldown turns remaining, bullet costs, whether the robot can
+     * hire, and that the given direction is not blocked.
      * 
-     * @param dir the direction to build in.
+     * @param dir the direction to build in
      * @return whether it is possible to hire a gardener in the given direction.
      *
      * @battlecode.doc.costlymethod
@@ -1070,12 +1070,12 @@ public strictfp interface RobotController {
     boolean canHireGardener(Direction dir);
     
     /**
-     * Hires a Gardener in the given direction. This is a core action.
+     * Hires a Gardener in the given direction.
      *
-     * @param dir the direction to spawn the GARDENER unit.
-     * @throws GameActionException if the build is bad: if you don't have enough
-     * bullets, if you have coreDelay, if the direction is not a good build
-     * direction, or if you are not of type ARCHON.
+     * @param dir the direction to spawn the Gardener
+     * @throws GameActionException if you don't have enough bullets, if
+     * the robot is still in build cooldown, if the direction is not a good build
+     * direction, or if this robot is not of an appropriate type.
      *
      * @battlecode.doc.costlymethod
      */
@@ -1144,11 +1144,11 @@ public strictfp interface RobotController {
     /**
      * Draw a dot on the game map for debugging purposes.
      *
-     * @param loc the location to draw the dot.
-     * @param red the red component of the dot's color.
-     * @param green the green component of the dot's color.
-     * @param blue the blue component of the dot's color.
-     * @throws GameActionException if loc is not a valid location on the map
+     * @param loc the location to draw the dot
+     * @param red the red component of the dot's color
+     * @param green the green component of the dot's color
+     * @param blue the blue component of the dot's color
+     * @throws GameActionException if loc is not a valid location on the map.
      *
      * @battlecode.doc.costlymethod
      */
@@ -1157,12 +1157,12 @@ public strictfp interface RobotController {
     /**
      * Draw a line on the game map for debugging purposes.
      *
-     * @param startLoc the location to draw the line from.
-     * @param endLoc the location to draw the line to.
-     * @param red the red component of the line's color.
-     * @param green the green component of the line's color.
-     * @param blue the blue component of the line's color.
-     * @throws GameActionException if startLoc or endLoc is not a valid location on the map
+     * @param startLoc the location to draw the line from
+     * @param endLoc the location to draw the line to
+     * @param red the red component of the line's color
+     * @param green the green component of the line's color
+     * @param blue the blue component of the line's color
+     * @throws GameActionException if startLoc or endLoc is not a valid location on the map.
      *
      * @battlecode.doc.costlymethod
      */
@@ -1178,8 +1178,8 @@ public strictfp interface RobotController {
      * If this method is called more than once with the same index in the same
      * game, the last call is what is saved for the next game.
      *
-     * @param index the index of the array to set.
-     * @param value the data that the team should remember for the next game.
+     * @param index the index of the array to set
+     * @param value the data that the team should remember for the next game
      * @throws java.lang.ArrayIndexOutOfBoundsException if {@code index} is less
      * than zero or greater than or equal to
      * {@link GameConstants#TEAM_MEMORY_LENGTH}.
@@ -1196,9 +1196,9 @@ public strictfp interface RobotController {
      * {@code mask == 0xFF} then only the eight least significant bits of the
      * memory will be set.
      *
-     * @param index the index of the array to set.
-     * @param value the data that the team should remember for the next game.
-     * @param mask indicates which bits should be set.
+     * @param index the index of the array to set
+     * @param value the data that the team should remember for the next game
+     * @param mask indicates which bits should be set
      * @throws java.lang.ArrayIndexOutOfBoundsException if {@code index} is less
      * than zero or greater than or equal to
      * {@link GameConstants#TEAM_MEMORY_LENGTH}.
@@ -1233,7 +1233,7 @@ public strictfp interface RobotController {
      * bits, you must run the client in lockstep mode and right click the
      * units.
      *
-     * @return this robot's control bits
+     * @return this robot's control bits.
      *
      * @battlecode.doc.costlymethod
      */

--- a/src/main/battlecode/common/RobotInfo.java
+++ b/src/main/battlecode/common/RobotInfo.java
@@ -86,7 +86,7 @@ public class RobotInfo implements  BodyInfo{
 
     /**
      * Returns the team that this robot is on.
-     * 
+     *
      * @return the team that this robot is on.
      */
     public Team getTeam() {

--- a/src/main/battlecode/common/RobotInfo.java
+++ b/src/main/battlecode/common/RobotInfo.java
@@ -33,12 +33,12 @@ public class RobotInfo implements  BodyInfo{
     public final double health;
     
     /**
-     * The number of times this robot has attacked in the current turn
+     * The number of times this robot has attacked in the current turn.
      */
     public final int attackCount;
     
     /**
-     * The number of times this robot has moved in the current turn
+     * The number of times this robot has moved in the current turn.
      */
     public final int moveCount;
 
@@ -85,35 +85,45 @@ public class RobotInfo implements  BodyInfo{
     }
 
     /**
-     * @return the team that this robot is on
+     * Returns the team that this robot is on.
+     * 
+     * @return the team that this robot is on.
      */
     public Team getTeam() {
         return team;
     }
 
     /**
-     * @return the type of this robot
+     * Returns the type of this robot.
+     *
+     * @return the type of this robot.
      */
     public RobotType getType() {
         return type;
     }
 
     /**
-     * @return the current health of this robot
+     * Returns the current health of this robot.
+     *
+     * @return the current health of this robot.
      */
     public double getHealth() {
         return health;
     }
 
     /**
-     * @return the number of times this robot has attacked in the current turn
+     * Returns the number of times this robot has attacked this turn.
+     *
+     * @return the number of times this robot has attacked this turn.
      */
     public int getAttackCount() {
         return attackCount;
     }
 
     /**
-     * @return the number of times this robot has moved in the current turn
+     * Returns the number of times this robot has moved this turn.
+     *
+     * @return the number of times this robot has moved this turn.
      */
     public int getMoveCount() {
         return moveCount;

--- a/src/main/battlecode/common/RobotType.java
+++ b/src/main/battlecode/common/RobotType.java
@@ -42,7 +42,7 @@ public enum RobotType {
     TANK            (GARDENER, 10,  100,  300,   2,   3f,   4,   7,  10,  1f, 10000),
     //                              HP    BC     BR   BS    AP   SR  BSR    STR   BCL
     /**
-     * An unit that specializes in movement and reconnaissance.
+     * A unit that specializes in movement and reconnaissance.
      *
      * @battlecode.doc.robottype
      */
@@ -101,7 +101,7 @@ public enum RobotType {
     public final float strideRadius;
 
     /**
-     * Base bytecode limit of this robot (halved if the robot does not have sufficient supply upkeep).
+     * Base bytecode limit of this robot.
      */
     public final int bytecodeLimit;
 

--- a/src/main/battlecode/common/RobotType.java
+++ b/src/main/battlecode/common/RobotType.java
@@ -14,35 +14,35 @@ public enum RobotType {
     ARCHON          (null,    0,    400,   -1,   2,  -1,  -1,   10,  15, 1,  20000),
     //                              HP      BC   BR   BS   AP   SR  BSR  STR   BCL
     /**
-     * The main producer unit to make other units and trees; can't build Archons or other Gardeners
+     * The main producer unit to make other units and trees; can't build Archons or other Gardeners.
      *
      * @battlecode.doc.robottype
      */
     GARDENER        (ARCHON,  10,   40,  100,   1,  -1,  -1,   7,  10,   1, 10000),
     //                              HP    BC   BR   BS   AP   SR  BSR  STR   BCL
     /**
-     * A melee based unit that specializes at cutting down trees
+     * A melee based unit that specializes at cutting down trees.
      *
      * @battlecode.doc.robottype
      */
     LUMBERJACK      (GARDENER,  10, 50,  100,   1,  -1,   2,   7,  10,  1.5f, 10000),
     //                              HP    BC   BR   BS   AP    SR  BSR  STR   BCL
     /**
-     * The basic fighting unit
+     * The basic fighting unit.
      *
      * @battlecode.doc.robottype
      */
     SOLDIER         (GARDENER,  10, 50,  100,   1,   2f,   2,   7,  10,   2, 10000),
     //                              HP    BC   BR     BS    AP   SR   BSR  STR   BCL
     /**
-     * A strong fighting unit
+     * A strong fighting unit.
      *
      * @battlecode.doc.robottype
      */
     TANK            (GARDENER, 10,  100,  300,   2,   3f,   4,   7,  10,  1f, 10000),
     //                              HP    BC     BR   BS    AP   SR  BSR    STR   BCL
     /**
-     * An unit that specializes in movement
+     * An unit that specializes in movement and reconnaissance.
      *
      * @battlecode.doc.robottype
      */
@@ -96,7 +96,7 @@ public enum RobotType {
     public final float bulletSightRadius;
 
     /**
-     * Maximum distance the robot can move per turn
+     * Maximum distance the robot can move per turn.
      */
     public final float strideRadius;
 
@@ -115,7 +115,7 @@ public enum RobotType {
     }
 
     /**
-     * Returns whether the robot can hire Gardeners
+     * Returns whether the robot can hire Gardeners.
      *
      * @return whether the robot can hire Gardeners.
      */
@@ -124,7 +124,7 @@ public enum RobotType {
     }
 
     /**
-     * Returns whether the robot can build trees and all units except Gardeners and Archons
+     * Returns whether the robot can build trees and all units except Gardeners and Archons.
      *
      * @return whether the robot can build.
      */
@@ -149,9 +149,9 @@ public enum RobotType {
     public boolean isBuildable() { return spawnSource == GARDENER; }
 
     /**
-     * Returns the starting health of this type of robot
+     * Returns the starting health of this type of robot.
      *
-     * @return the starting health of this type of robot
+     * @return the starting health of this type of robot.
      */
     public float getStartingHealth() {
         return this == RobotType.ARCHON || this == RobotType.GARDENER ? this.maxHealth : .20F * this.maxHealth;

--- a/src/main/battlecode/common/Team.java
+++ b/src/main/battlecode/common/Team.java
@@ -45,7 +45,7 @@ public enum Team {
      * Returns whether a robot of this team is a player-controlled entity
      * (team A or team B).
      *
-     * @return whether a robot of this team is player-controlled.
+     * @return true a robot of this team is player-controlled; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */


### PR DESCRIPTION
Javadocs are in general cleaner and more self-consistent now. A few comments should now be clearer to contestants, some errors have been corrected, and there were also a few leftover references to old functionality (e.g. core delays) that I've now removed.