### PR TITLE
Allow null directions in MapLocation operations

### DIFF
--- a/src/main/battlecode/common/MapLocation.java
+++ b/src/main/battlecode/common/MapLocation.java
@@ -221,6 +221,9 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      * @battlecode.doc.costlymethod
      */
     public final MapLocation add(Direction direction) {
+        if(direction == null) {
+            return new MapLocation(x ,y);
+        }
         float dx = (float)Math.cos(direction.radians);
         float dy = (float)Math.sin(direction.radians);
         return new MapLocation(x + dx, y + dy);
@@ -254,6 +257,9 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      * @battlecode.doc.costlymethod
      */
     public final MapLocation add(Direction direction, float dist) {
+        if(direction == null) {
+            return new MapLocation(x ,y);
+        }
         float dx = (float)(dist * Math.cos(direction.radians));
         float dy = (float)(dist * Math.sin(direction.radians));
         return new MapLocation(x + dx, y + dy);
@@ -288,6 +294,9 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      * @battlecode.doc.costlymethod
      */
     public final MapLocation subtract(Direction direction) {
+        if(direction == null) {
+            return new MapLocation(x,y);
+        }
         return this.add(direction.opposite());
     }
 
@@ -320,6 +329,9 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      * @battlecode.doc.costlymethod
      */
     public final MapLocation subtract(Direction direction, float dist) {
+        if(direction == null) {
+            return new MapLocation(x,y);
+        }
         return this.add(direction.opposite(), dist);
     }
 

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -800,6 +800,10 @@ public class RobotControllerTest {
                 exception = true;
             }
             assertFalse(exception);
+
+            MapLocation loc1 = new MapLocation(5,5);
+            MapLocation loc2 = loc1.add(null,5);
+            assertEquals(loc1,loc2);
         });
     }
 }

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -843,7 +843,7 @@ public class RobotControllerTest {
             MapLocation loc1 = new MapLocation(5, 5);
             MapLocation loc2 = loc1.add(null, 5);
             assertEquals(loc1, loc2);
-        }
+        });
     }
 
 }

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -774,4 +774,32 @@ public class RobotControllerTest {
             assertEquals(nullBot,null);
         });
     }
+
+    @Test
+    public void overlappingScoutTest() throws GameActionException {
+        LiveMap map = new TestMapBuilder("test", new MapLocation(0,0), 10, 10, 1337, 100)
+                .build();
+
+        // This creates the actual game.
+        TestGame game = new TestGame(map);
+
+        final int scoutA = game.spawn(3, 5, RobotType.SCOUT, Team.A);
+        final int neutralTree = game.spawnTree(5,5,1,Team.NEUTRAL,0,null);
+
+        game.round((id, rc) -> {
+            if(id != scoutA) return;
+
+            TreeInfo[] nearbyTrees = rc.senseNearbyTrees();
+            rc.move(nearbyTrees[0].getLocation());
+
+            boolean exception = false;
+            try {
+                nearbyTrees = rc.senseNearbyTrees();
+            } catch (Exception e) {
+                System.out.println("Scout threw an error when trying to sense tree at its location, this shouldn't happen");
+                exception = true;
+            }
+            assertFalse(exception);
+        });
+    }
 }


### PR DESCRIPTION
MapLocation methods didn't check for null, leading to nullPointerExceptions in code that should work. Null direction now basically means "no direction", so "Add distance 5 in direction `null` to location x" results in location x, as opposed to a nullPointerException.

Added tests to confirm functionality.

Resolves #331 
Resolves #334 