### PR TITLE
Unique robot random seeds

### DIFF
--- a/src/main/battlecode/world/control/PlayerControlProvider.java
+++ b/src/main/battlecode/world/control/PlayerControlProvider.java
@@ -86,7 +86,7 @@ public class PlayerControlProvider implements RobotControlProvider {
             final SandboxedRobotPlayer player = new SandboxedRobotPlayer(
                     teamPackage,
                     robot.getController(),
-                    gameWorld.getMapSeed(),
+                    robot.getID(),
                     factory.createLoader(),
                     robotOut
             );


### PR DESCRIPTION
Changed robot's random seed to be its own ID, rather than map seed. If IDs weren't already deterministic, then we have another problem.

Resolves #347 