### PR TITLE
Instrumenter Fixes

### DIFF
--- a/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
+++ b/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
@@ -144,10 +144,14 @@ public class ClassReferenceUtil {
     public String classReference(String className, boolean checkDisallowed) {
         if (className == null) return null;
 
+        // Classes of the form "[[[Lorg.dogs.Bone;" (e.g. object arrays)
+        // should be replaced with classes of the form "[[[" + classReference(org.dogs.Bone) + ";"
         if (className.charAt(0) == '[') {
             int arrayIndex = className.lastIndexOf('[');
             if (className.charAt(arrayIndex + 1) == 'L') {
-                return className.substring(0, arrayIndex + 2) + classReference(className.substring(arrayIndex + 2), checkDisallowed);
+                return className.substring(0, arrayIndex + 2)
+                        + classReference(className.substring(arrayIndex + 2, className.length() - 1), checkDisallowed)
+                        + ';';
             } else {
                 return className;
             }

--- a/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
+++ b/src/main/battlecode/instrumenter/bytecode/ClassReferenceUtil.java
@@ -145,7 +145,7 @@ public class ClassReferenceUtil {
         if (className == null) return null;
 
         // Classes of the form "[[[Lorg.dogs.Bone;" (e.g. object arrays)
-        // should be replaced with classes of the form "[[[" + classReference(org.dogs.Bone) + ";"
+        // should be replaced with classes of the form "[[[L" + classReference(org.dogs.Bone) + ";"
         if (className.charAt(0) == '[') {
             int arrayIndex = className.lastIndexOf('[');
             if (className.charAt(arrayIndex + 1) == 'L') {

--- a/src/main/battlecode/server/ErrorReporter.java
+++ b/src/main/battlecode/server/ErrorReporter.java
@@ -31,10 +31,10 @@ public class ErrorReporter {
     }
 
     public static void report(Throwable e, boolean ourFault) {
+        printStackTrace(e);
         if (ourFault) {
             Server.warn("\n\n");
             printReportString();
-            printStackTrace(e);
         }
     }
 


### PR DESCRIPTION
There were a few weird bits of code (i.e. wrong bits of code) that flew under the radar all these years. This should fix them?

Specifically:
You can now load arrays of player classes.
You can now use packages like `battlecodeutil`.
Errors are now reported better in some cases.