### PR TITLE
fixed canSensePartOfCircle/canSeseAllOfCircle

### DIFF
--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -186,11 +186,21 @@ public strictfp interface RobotController {
      * Senses whether the given location is within the robot's sensor range.
      *
      * @param loc the location to check
-     * @return true the given location is within the robot's sensor range; false otherwise.
+     * @return true if the given location is within the robot's sensor range; false otherwise.
      *
      * @battlecode.doc.costlymethod
      */
     boolean canSenseLocation(MapLocation loc);
+
+    /**
+     * Senses whether a point at the given radius is within the robot's sensor range.
+     *
+     * @param radius the radius to check
+     * @return true if the given location is within the robot's sensor range; false otherwise.
+     *
+     * @battlecode.doc.costlymethod
+     */
+    boolean canSenseRadius(float radius);
 
     /**
      * Senses whether any portion of the given circle is within the robot's sensor range.

--- a/src/main/battlecode/world/InternalRobot.java
+++ b/src/main/battlecode/world/InternalRobot.java
@@ -167,6 +167,10 @@ public strictfp class InternalRobot {
         return this.location.distanceTo(toSense) <= this.type.sensorRadius;
     }
 
+    public boolean canSenseRadius(float radius) {
+        return radius <= this.type.sensorRadius;
+    }
+
     public boolean canInteractWithLocation(MapLocation toInteract){
         return this.location.distanceTo(toInteract) <= (this.type.strideRadius+this.type.bodyRadius);
     }

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -211,17 +211,20 @@ public final strictfp class RobotControllerImpl implements RobotController {
     }
 
     @Override
+    public boolean canSenseRadius(float radius) {
+        return this.robot.canSenseRadius(radius);
+    }
+
+    @Override
     public boolean canSensePartOfCircle(MapLocation center, float radius){
         assertNotNull(center);
-        MapLocation closestPointOnCircle = center.add(center.directionTo(getLocation()), radius);
-        return canSenseLocation(closestPointOnCircle);
+        return canSenseRadius(getLocation().distanceTo(center)-radius);
     }
 
     @Override
     public boolean canSenseAllOfCircle(MapLocation center, float radius){
         assertNotNull(center);
-        MapLocation furthestPointOnCircle = center.add(center.directionTo(getLocation()).opposite(), radius);
-        return canSenseLocation(furthestPointOnCircle);
+        return canSenseRadius(getLocation().distanceTo(center)+radius);
     }
 
     @Override

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -896,4 +896,27 @@ public class RobotControllerTest {
         }
     }
 
+    @Test
+    public void testNullIsCircleOccupied() throws GameActionException {
+        LiveMap map = new TestMapBuilder("test", new MapLocation(0,0), 10, 10, 1337, 100)
+                .build();
+
+        // This creates the actual game.
+        TestGame game = new TestGame(map);
+
+        final int gardener = game.spawnTree(5,5,5,Team.A,0,null);
+
+
+        game.round((id, rc) -> {
+            if(id != gardener) return;
+
+            boolean exception = false;
+            try {
+                assertFalse(rc.isCircleOccupiedExceptByThisRobot(rc.getLocation(), 3));
+            } catch(Exception e) {
+                exception = true;
+            }
+            assertFalse(exception);
+        });
+    }
 }


### PR DESCRIPTION
Someone was getting a nullPointerException when they called `rc.isCircleOccupiedExceptByThisRobot(rc.getLocation(), 3)`. I couldn't replicate it, but I found what should have been causing it and fixed it.

Resolves #357 