### PR TITLE
Better websocket procedures

### DIFF
--- a/src/main/battlecode/server/Config.java
+++ b/src/main/battlecode/server/Config.java
@@ -32,6 +32,7 @@ public class Config {
 
         defaults.setProperty("bc.server.websocket", "true");
         defaults.setProperty("bc.server.port", "6175");
+        defaults.setProperty("bc.server.wait-for-client", "false");
 
         defaults.setProperty("bc.server.save-file", "match.rms");
         defaults.setProperty("bc.server.transcribe-input", "match.rms");

--- a/src/main/battlecode/server/NetServer.java
+++ b/src/main/battlecode/server/NetServer.java
@@ -24,6 +24,8 @@ public class NetServer extends WebSocketServer {
     private final List<byte[]> previousEvents;
     private final BlockingQueue<byte[]> incomingEvents;
 
+    private boolean waitForClient;
+
     private boolean done = false;
     private boolean connected = false;
 
@@ -33,8 +35,10 @@ public class NetServer extends WebSocketServer {
      * Create a new server.
      * @param port
      */
-    public NetServer(int port) {
+    public NetServer(int port, boolean waitForClient) {
         super(new InetSocketAddress(port));
+
+        this.waitForClient = waitForClient;
 
         previousEvents = new ArrayList<>();
         incomingEvents = new ArrayBlockingQueue<>(64);
@@ -69,15 +73,17 @@ public class NetServer extends WebSocketServer {
         queueThread.start();
         super.start();
 
-        System.out.println("Waiting for connection from client...");
-        try {
-            while (!connected) {
-                Thread.sleep(300);
+        if (waitForClient) {
+            System.out.println("Waiting for connection from client...");
+            try {
+                while (!connected) {
+                    Thread.sleep(300);
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Bad things happened");
             }
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Bad things happened");
+            System.out.println("Connection received!");
         }
-        System.out.println("Connection received!");
     }
 
     /**

--- a/src/main/battlecode/server/NetServer.java
+++ b/src/main/battlecode/server/NetServer.java
@@ -25,6 +25,7 @@ public class NetServer extends WebSocketServer {
     private final BlockingQueue<byte[]> incomingEvents;
 
     private boolean done = false;
+    private boolean connected = false;
 
     private Thread queueThread;
 
@@ -67,6 +68,16 @@ public class NetServer extends WebSocketServer {
 
         queueThread.start();
         super.start();
+
+        System.out.println("Waiting for connection from client...");
+        try {
+            while (!connected) {
+                Thread.sleep(300);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Bad things happened");
+        }
+        System.out.println("Connection received!");
     }
 
     /**
@@ -124,6 +135,8 @@ public class NetServer extends WebSocketServer {
     @Override
     public void onOpen(WebSocket client, ClientHandshake handshake) {
         synchronized (connections()) {
+            connected = true;
+
             for (byte[] event : previousEvents) {
                 client.send(event);
             }

--- a/src/main/battlecode/server/Server.java
+++ b/src/main/battlecode/server/Server.java
@@ -119,7 +119,7 @@ public strictfp class Server implements Runnable {
         final NetServer netServer;
         if (options.getBoolean("bc.server.websocket")) {
             netServer = new NetServer(options.getInt("bc.server.port"),
-                                      options.getBoolean("bc.server.wait.for.client"));
+                                      options.getBoolean("bc.server.wait-for-client"));
             netServer.start();
         } else {
             netServer = null;

--- a/src/main/battlecode/server/Server.java
+++ b/src/main/battlecode/server/Server.java
@@ -118,7 +118,8 @@ public strictfp class Server implements Runnable {
     public void run() {
         final NetServer netServer;
         if (options.getBoolean("bc.server.websocket")) {
-            netServer = new NetServer(options.getInt("bc.server.port"));
+            netServer = new NetServer(options.getInt("bc.server.port"),
+                                      options.getBoolean("bc.server.wait.for.client"));
             netServer.start();
         } else {
             netServer = null;


### PR DESCRIPTION
Resolves https://github.com/battlecode/battlecode-client-17/issues/113 .

Server would sometimes start up, run match, and close before client could establish a connection, thus causing match to not play in client. Added new option for server to block until a client has connected.