### PR TITLE
silence slf4j output in scaffold

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,10 @@ repositories {
 }
 
 dependencies {
-  compile (    
+  compile (
+    [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'],
+    [group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'],
+
     // normal dependencies
     [group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'],
     [group: 'commons-cli', name: 'commons-cli', version: '1.3.1'],


### PR DESCRIPTION
resolves #410.

Turns out SLF4J is necessary to include after all, though it may have a bug; see http://stackoverflow.com/questions/11916706/slf4j-failed-to-load-class-org-slf4j-impl-staticloggerbinder-error . This solution may or may not just be a work-around.