### PR TITLE
Turn order

### DIFF
--- a/src/main/battlecode/world/InternalBody.java
+++ b/src/main/battlecode/world/InternalBody.java
@@ -1,0 +1,6 @@
+package battlecode.world;
+
+/**
+ * An empty interface for internally representing bullets, robots, and trees.
+ */
+public strictfp interface InternalBody {}

--- a/src/main/battlecode/world/InternalBullet.java
+++ b/src/main/battlecode/world/InternalBullet.java
@@ -5,7 +5,7 @@ import battlecode.common.*;
 /**
  * The representation of a bullet used by the server.
  */
-public strictfp class InternalBullet {
+public strictfp class InternalBullet implements InternalBody {
     private final GameWorld gameWorld;
     private final LiveMap gameMap;
 

--- a/src/main/battlecode/world/InternalRobot.java
+++ b/src/main/battlecode/world/InternalRobot.java
@@ -6,7 +6,7 @@ import battlecode.schema.Action;
 /**
  * The representation of a robot used by the server.
  */
-public strictfp class InternalRobot {
+public strictfp class InternalRobot implements InternalBody {
     private final RobotControllerImpl controller;
     private final GameWorld gameWorld;
 

--- a/src/main/battlecode/world/ObjectInfo.java
+++ b/src/main/battlecode/world/ObjectInfo.java
@@ -308,7 +308,7 @@ public strictfp class ObjectInfo {
         // before its parent next updates, and after any bullets previously fired
         // by this robot have updated again.
         int parentIndex = dynamicBodyExecOrder.indexOf(parent.getID());
-        dynamicBodyExecOrder.insert(id, parentIndex);
+        dynamicBodyExecOrder.insert(parentIndex, id);
 
         MapLocation loc = bullet.getLocation();
         bulletIndex.add(fromPoint(loc),bullet.getID());

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -648,7 +648,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
 
         // Fire center bullet
         int bulletID = gameWorld.spawnBullet(getTeam(), getType().bulletSpeed, getType().attackPower,
-                getLocation().add(centerDir, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), centerDir);
+                getLocation().add(centerDir, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), centerDir, this.robot);
         gameWorld.getMatchMaker().addAction(getID(), actionType, bulletID);
 
         // Fire side bullets
@@ -656,13 +656,13 @@ public final strictfp class RobotControllerImpl implements RobotController {
             // Fire left bullet
             Direction dirLeft = centerDir.rotateLeftDegrees(i * spreadDegrees);
             bulletID = gameWorld.spawnBullet(getTeam(), getType().bulletSpeed, getType().attackPower,
-                    getLocation().add(dirLeft, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), dirLeft);
+                    getLocation().add(dirLeft, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), dirLeft, this.robot);
             gameWorld.getMatchMaker().addAction(getID(), actionType, bulletID);
 
             // Fire right bullet
             Direction dirRight = centerDir.rotateRightDegrees(i * spreadDegrees);
             bulletID = gameWorld.spawnBullet(getTeam(), getType().bulletSpeed, getType().attackPower,
-                    getLocation().add(dirRight, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), dirRight);
+                    getLocation().add(dirRight, getType().bodyRadius + GameConstants.BULLET_SPAWN_OFFSET), dirRight, this.robot);
             gameWorld.getMatchMaker().addAction(getID(), actionType, bulletID);
         }
     }


### PR DESCRIPTION
Changes execution order.

Previous: robots > trees > bullets, in order of spawn

Robots and bullets now update during the same "phase", with bullets updating immediately before the robot that fired them. Robots still execute in spawn order, and bullets fired from the same robot also execute in spawn order.

This may need more optimization before being merged, as it potentially doubles the load on the server for running games.

Also, this probably shouldn't be merged before the sprint tournament, as it constitutes a relatively significant change to the layout of the game.