### PR TITLE
After-sprint spec changes

### DIFF
--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -156,6 +156,9 @@ public interface GameConstants {
      */
     float GENERAL_SPAWN_OFFSET = .01f;
 
+    /** The distance around a robot's edge it can interact with robots/trees (water, shake, chope, etc) */
+    float INTERACTION_DIST_FROM_EDGE = 1f;
+
     /** The amount of health a tree gains when watered. */
     float WATER_HEALTH_REGEN_RATE = BULLET_TREE_MAX_HEALTH/10f;
 

--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -156,7 +156,7 @@ public interface GameConstants {
      */
     float GENERAL_SPAWN_OFFSET = .01f;
 
-    /** The distance around a robot's edge it can interact with robots/trees (water, shake, chope, etc) */
+    /** The distance around a robot's edge it can interact with robots/trees (water, shake, chop, etc) */
     float INTERACTION_DIST_FROM_EDGE = 1f;
 
     /** The amount of health a tree gains when watered. */

--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -145,10 +145,10 @@ public interface GameConstants {
     // *********************************
 
     /** The price, in bullets, of 1 victory point at the start of the game */
-    int VP_BASE_COST = 5;
+    float VP_BASE_COST = 7.5f;
 
     /** The price, in bullets, the victory point cost increases each turn */
-    float VP_INCREASE_PER_ROUND = 15f / 3000f;
+    float VP_INCREASE_PER_ROUND = 12.5f / 3000f;
 
     /**
      * The distance, as measured at its minimum value, between the bodies

--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -144,8 +144,11 @@ public interface GameConstants {
     // ****** MISCELLANEOUS ************
     // *********************************
 
-    /** The price, in bullets, of 1 victory point. */
-    int BULLET_EXCHANGE_RATE = 10;
+    /** The price, in bullets, of 1 victory point at the start of the game */
+    int VP_BASE_COST = 5;
+
+    /** The price, in bullets, the victory point cost increases each turn */
+    float VP_INCREASE_PER_ROUND = 15f / 3000f;
 
     /**
      * The distance, as measured at its minimum value, between the bodies

--- a/src/main/battlecode/common/GameConstants.java
+++ b/src/main/battlecode/common/GameConstants.java
@@ -88,7 +88,7 @@ public interface GameConstants {
     /**
      * The damage a tank does to a tree when it attempts to move on top of it.
      */
-    float TANK_BODY_DAMAGE = 2;
+    float TANK_BODY_DAMAGE = 4;
     
     /**
      * The fraction of max health which trees and gardener-produced robots start at.
@@ -138,7 +138,7 @@ public interface GameConstants {
     // *********************************
 
     /** The size of the team-shared array for signaling. */
-    int BROADCAST_MAX_CHANNELS = 1000;
+    int BROADCAST_MAX_CHANNELS = 10000;
 
     // *********************************
     // ****** MISCELLANEOUS ************

--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -53,6 +53,15 @@ public strictfp interface RobotController {
     int getTeamVictoryPoints();
 
     /**
+     * Returns your opponent's total victory points.
+     *
+     * @return your opponent's total victory points.
+     *
+     * @battlecode.doc.costlymethod
+     */
+    int getOpponentVictoryPoints();
+
+    /**
      * Returns the number of robots on your team, including your archons.
      * If this number ever reaches zero, the opposing team will automatically
      * win by destruction.
@@ -1123,6 +1132,14 @@ public strictfp interface RobotController {
     // ***********************************
     // ****** OTHER ACTION METHODS *******
     // ***********************************
+
+    /**
+     * Returns the current cost of a victory point in bullets. This varies based
+     * on the round number, and is equal to 10 + RoundNum/300
+     *
+     * @battlecode.doc.costlymethod
+     */
+    float getVictoryPointCost();
 
     /**
      * Donates the given amount of bullets to the reforestation fund in

--- a/src/main/battlecode/common/RobotController.java
+++ b/src/main/battlecode/common/RobotController.java
@@ -1135,7 +1135,8 @@ public strictfp interface RobotController {
 
     /**
      * Returns the current cost of a victory point in bullets. This varies based
-     * on the round number, and is equal to 10 + RoundNum/300
+     * on the round number, and is equal to {@link GameConstants#VP_BASE_COST} +
+     * NumRounds * {@link GameConstants#VP_INCREASE_PER_ROUND}.
      *
      * @battlecode.doc.costlymethod
      */

--- a/src/main/battlecode/common/RobotType.java
+++ b/src/main/battlecode/common/RobotType.java
@@ -11,42 +11,42 @@ public enum RobotType {
      *
      * @battlecode.doc.robottype
      */
-    ARCHON          (null,    0,    400,   -1,   2,  -1,  -1,   10,  15, 1,  20000),
+    ARCHON          (null,    0,    400,   -1,   2,  -1,  -1,   10,  15, 0.5f,  20000),
     //                              HP      BC   BR   BS   AP   SR  BSR  STR   BCL
     /**
      * The main producer unit to make other units and trees; can't build Archons or other Gardeners.
      *
      * @battlecode.doc.robottype
      */
-    GARDENER        (ARCHON,  10,   40,  100,   1,  -1,  -1,   7,  10,   1, 10000),
+    GARDENER        (ARCHON,  10,   40,  100,   1,  -1,  -1,   7,  10,   0.5f, 10000),
     //                              HP    BC   BR   BS   AP   SR  BSR  STR   BCL
     /**
      * A melee based unit that specializes at cutting down trees.
      *
      * @battlecode.doc.robottype
      */
-    LUMBERJACK      (GARDENER,  10, 50,  100,   1,  -1,   2,   7,  10,  1.25f, 10000),
+    LUMBERJACK      (GARDENER,  10, 50,  100,   1,  -1,   2,   7,  10,  0.75f, 10000),
     //                              HP    BC   BR   BS   AP    SR  BSR  STR   BCL
     /**
      * The basic fighting unit.
      *
      * @battlecode.doc.robottype
      */
-    SOLDIER         (GARDENER,  10, 50,  100,   1,   2f,   2,   7,  10,   1.75f, 10000),
+    SOLDIER         (GARDENER,  10, 50,  100,   1,   2f,   2,   7,  10,   1f, 10000),
     //                              HP    BC   BR     BS    AP   SR   BSR  STR   BCL
     /**
      * A strong fighting unit.
      *
      * @battlecode.doc.robottype
      */
-    TANK            (GARDENER, 10,  200,  300,   2,   4,   5,   7,  10,  1f, 10000),
+    TANK            (GARDENER, 10,  200,  300,   2,   4,   5,   7,  10,  0.5f, 10000),
     //                              HP    BC     BR   BS    AP   SR  BSR    STR   BCL
     /**
      * A unit that specializes in movement and reconnaissance.
      *
      * @battlecode.doc.robottype
      */
-    SCOUT           (GARDENER,  10, 10,   80,   1, 1.5f,   0.5f,   14,  20,  (float)2, 10000),
+    SCOUT           (GARDENER,  10, 10,   80,   1, 1.5f,   0.5f,   14,  20,  1.25f, 10000),
     //                              HP    BC   BR    BS   AP   SR  BSR         STR   BCL
     ;
     

--- a/src/main/battlecode/common/RobotType.java
+++ b/src/main/battlecode/common/RobotType.java
@@ -46,7 +46,7 @@ public enum RobotType {
      *
      * @battlecode.doc.robottype
      */
-    SCOUT           (GARDENER,  10, 10,   80,   1, 1.5f,   0.5f,   12,  20,  (float)2, 10000),
+    SCOUT           (GARDENER,  10, 10,   80,   1, 1.5f,   0.5f,   14,  20,  (float)2, 10000),
     //                              HP    BC   BR    BS   AP   SR  BSR         STR   BCL
     ;
     

--- a/src/main/battlecode/common/RobotType.java
+++ b/src/main/battlecode/common/RobotType.java
@@ -25,28 +25,28 @@ public enum RobotType {
      *
      * @battlecode.doc.robottype
      */
-    LUMBERJACK      (GARDENER,  10, 50,  100,   1,  -1,   2,   7,  10,  1.5f, 10000),
+    LUMBERJACK      (GARDENER,  10, 50,  100,   1,  -1,   2,   7,  10,  1.25f, 10000),
     //                              HP    BC   BR   BS   AP    SR  BSR  STR   BCL
     /**
      * The basic fighting unit.
      *
      * @battlecode.doc.robottype
      */
-    SOLDIER         (GARDENER,  10, 50,  100,   1,   2f,   2,   7,  10,   2, 10000),
+    SOLDIER         (GARDENER,  10, 50,  100,   1,   2f,   2,   7,  10,   1.75f, 10000),
     //                              HP    BC   BR     BS    AP   SR   BSR  STR   BCL
     /**
      * A strong fighting unit.
      *
      * @battlecode.doc.robottype
      */
-    TANK            (GARDENER, 10,  200,  300,   2,   3f,   4,   7,  10,  1f, 10000),
+    TANK            (GARDENER, 10,  200,  300,   2,   4,   5,   7,  10,  1f, 10000),
     //                              HP    BC     BR   BS    AP   SR  BSR    STR   BCL
     /**
      * A unit that specializes in movement and reconnaissance.
      *
      * @battlecode.doc.robottype
      */
-    SCOUT           (GARDENER,  10, 20,   80,   1, 1.5f,   1,   10,  20,  (float)2.5, 10000),
+    SCOUT           (GARDENER,  10, 10,   80,   1, 1.5f,   0.5f,   12,  20,  (float)2, 10000),
     //                              HP    BC   BR    BS   AP   SR  BSR         STR   BCL
     ;
     

--- a/src/main/battlecode/instrumenter/bytecode/resources/MethodCosts.txt
+++ b/src/main/battlecode/instrumenter/bytecode/resources/MethodCosts.txt
@@ -65,6 +65,7 @@ battlecode/common/RobotController/getID                             1     true
 battlecode/common/RobotController/getInitialArchonLocations         100   true
 battlecode/common/RobotController/getLocation                       1     true
 battlecode/common/RobotController/getMoveCount                      1     true
+battlecode/common/RobotController/getOpponentVictoryPoints          1     true
 battlecode/common/RobotController/getRobotCount                     20    true
 battlecode/common/RobotController/getRoundLimit                     1     true
 battlecode/common/RobotController/getRoundNum                       1     true
@@ -74,6 +75,7 @@ battlecode/common/RobotController/getTeamMemory                     0     true
 battlecode/common/RobotController/getTeamVictoryPoints              1     true
 battlecode/common/RobotController/getTreeCount                      20    true
 battlecode/common/RobotController/getType                           1     true
+battlecode/common/RobotController/getVictoryPointCost               0     true
 battlecode/common/RobotController/hasAttacked                       1     true
 battlecode/common/RobotController/hasMoved                          1     true
 battlecode/common/RobotController/hasRobotBuildRequirements         5     true

--- a/src/main/battlecode/world/InternalRobot.java
+++ b/src/main/battlecode/world/InternalRobot.java
@@ -176,11 +176,11 @@ public strictfp class InternalRobot {
     }
 
     public boolean canInteractWithLocation(MapLocation toInteract){
-        return this.location.distanceTo(toInteract) <= (this.type.strideRadius+this.type.bodyRadius);
+        return this.location.distanceTo(toInteract) <= (this.type.bodyRadius + GameConstants.INTERACTION_DIST_FROM_EDGE);
     }
 
     public boolean canInteractWithCircle(MapLocation center, float radius) {
-        return this.location.distanceTo(center) <= (this.type.strideRadius+this.type.bodyRadius+radius);
+        return this.location.distanceTo(center) <= (this.type.bodyRadius + radius + GameConstants.INTERACTION_DIST_FROM_EDGE);
     }
 
     // ******************************************

--- a/src/main/battlecode/world/RobotControllerImpl.java
+++ b/src/main/battlecode/world/RobotControllerImpl.java
@@ -94,6 +94,11 @@ public final strictfp class RobotControllerImpl implements RobotController {
     }
 
     @Override
+    public int getOpponentVictoryPoints() {
+        return gameWorld.getTeamInfo().getVictoryPoints(getTeam().opponent());
+    }
+
+    @Override
     public int getRobotCount(){
         return gameWorld.getObjectInfo().getRobotCount(getTeam());
     }
@@ -1135,10 +1140,15 @@ public final strictfp class RobotControllerImpl implements RobotController {
     // ***********************************
 
     @Override
+    public float getVictoryPointCost() {
+        return GameConstants.VP_BASE_COST + GameConstants.VP_INCREASE_PER_ROUND * getRoundNum();
+    }
+
+    @Override
     public void donate(float bullets) throws GameActionException{
         assertNonNegative(bullets);
         assertHaveBulletCosts(bullets);
-        int gainedVictorPoints = (int)bullets / GameConstants.BULLET_EXCHANGE_RATE;
+        int gainedVictorPoints = (int)Math.floor(bullets / getVictoryPointCost());
         gameWorld.getTeamInfo().adjustBulletSupply(getTeam(), -bullets);
         gameWorld.getTeamInfo().adjustVictoryPoints(getTeam(), gainedVictorPoints);
         gameWorld.setWinnerIfVictoryPoints();

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -615,13 +615,13 @@ public class RobotControllerTest {
 
         game.round((id, rc) -> {
             if (id != archonA) return;
-            rc.donate(100);
-            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-100,EPSILON);
-            assertEquals(rc.getTeamVictoryPoints(),100/10);
-            rc.donate(9);
-            rc.donate(9);
-            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-118,EPSILON);
-            assertEquals(rc.getTeamVictoryPoints(),100/10);
+            rc.donate(rc.getVictoryPointCost()*10);
+            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-rc.getVictoryPointCost()*10,EPSILON);
+            assertEquals(rc.getTeamVictoryPoints(),10);
+            rc.donate(rc.getVictoryPointCost()-0.1f);
+            rc.donate(rc.getVictoryPointCost()-0.1f);
+            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-rc.getVictoryPointCost()*12+0.2f,EPSILON);
+            assertEquals(rc.getTeamVictoryPoints(),10);
 
             // Try to donate negative bullets, should fail.
             boolean exception = false;
@@ -645,11 +645,11 @@ public class RobotControllerTest {
         // No winner yet
         assertEquals(game.getWorld().getWinner(),null);
 
-        // Give TeamA lots of bullets
-        game.getWorld().getTeamInfo().adjustBulletSupply(Team.A,GameConstants.VICTORY_POINTS_TO_WIN*GameConstants.BULLET_EXCHANGE_RATE);
-
         game.round((id, rc) -> {
             if(id != archonA) return;
+
+            // Give TeamA lots of bullets
+            game.getWorld().getTeamInfo().adjustBulletSupply(Team.A,GameConstants.VICTORY_POINTS_TO_WIN*rc.getVictoryPointCost());
 
             rc.donate(rc.getTeamBullets());
         });
@@ -1069,7 +1069,7 @@ public class RobotControllerTest {
                 RobotInfo[] robots = rc.senseNearbyRobots(-1, rc.getTeam().opponent());
                 assertEquals(robots.length, 0);
                 assertEquals(rc.senseNearbyBullets(-1).length,1);
-                rc.fireSingleShot(rc.getLocation().directionTo(robots[0].getLocation()));
+                rc.fireSingleShot(Direction.EAST);
                 assertEquals(rc.senseNearbyBullets(-1).length,2);
             }
         });

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -626,7 +626,7 @@ public class RobotControllerTest {
             assertEquals(rc.getTeamVictoryPoints(),10);
             rc.donate(rc.getVictoryPointCost()-0.1f);
             rc.donate(rc.getVictoryPointCost()-0.1f);
-            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-rc.getVictoryPointCost()*12+0.2f,EPSILON);
+            assertEquals(rc.getTeamBullets(),GameConstants.BULLETS_INITIAL_AMOUNT-rc.getVictoryPointCost()*12+0.2f,1E-4);
             assertEquals(rc.getTeamVictoryPoints(),10);
 
             // Try to donate negative bullets, should fail.

--- a/src/test/battlecode/world/RobotControllerTest.java
+++ b/src/test/battlecode/world/RobotControllerTest.java
@@ -205,7 +205,7 @@ public class RobotControllerTest {
         // This creates the actual game.
         TestGame game = new TestGame(map);
         
-        final int tankB = game.spawn(2, 5, RobotType.TANK, Team.B);
+        final int tankB = game.spawn(3.25f, 5, RobotType.TANK, Team.B);
         final int neutralTree = game.spawnTree(7, 5, 1, Team.NEUTRAL, 0, null);
         game.waitRounds(20); // Wait for units to mature
         
@@ -238,7 +238,7 @@ public class RobotControllerTest {
             assertTrue(rc.hasMoved());
             assertFalse(rc.getLocation().equals(originalLoc)); // Tank should have moved
         });
-        // Mpve tank into tree
+        // Move tank into tree
         game.round((id, rc) -> {
             if (id != tankB) return;
             
@@ -289,7 +289,7 @@ public class RobotControllerTest {
         // This creates the actual game.
         TestGame game = new TestGame(map);
         
-        final int lumberjackA = game.spawn(2, 5, RobotType.LUMBERJACK, Team.A);
+        final int lumberjackA = game.spawn(2.5f, 5, RobotType.LUMBERJACK, Team.A);
         final int soldierA = game.spawn(3, (float)7.1, RobotType.SOLDIER, Team.A);
         final int soldierB = game.spawn(3, (float)2.9, RobotType.SOLDIER, Team.B);
         final int neutralTree = game.spawnTree(6, 5, 1, Team.NEUTRAL, 0, null);
@@ -473,7 +473,7 @@ public class RobotControllerTest {
         // This creates the actual game.
         TestGame game = new TestGame(map);
 
-        final int archonA = game.spawn(3, 5, RobotType.ARCHON, Team.A);
+        final int archonA = game.spawn(4, 5, RobotType.ARCHON, Team.A);
         final int scoutA = game.spawn(7.5f, 5, RobotType.SCOUT, Team.A);
         final int scoutB = game.spawn(7.5f, 2, RobotType.SCOUT, Team.A);
         final int neutralTree = game.spawnTree(9f,5, 1, Team.NEUTRAL, 0, null);
@@ -489,6 +489,12 @@ public class RobotControllerTest {
 
             assertFalse(rc.canMove(originalArchonALoc));
             assertFalse(rc.canMove(scoutBLoc));
+            assertTrue(rc.canMove(neutralTreeLoc)); // Scouts can go over trees
+            rc.move(neutralTreeLoc);
+        });
+
+        game.round((id, rc) -> {
+            if (id != scoutA) return;
             assertTrue(rc.canMove(neutralTreeLoc)); // Scouts can go over trees
             rc.move(neutralTreeLoc);
         });
@@ -542,7 +548,7 @@ public class RobotControllerTest {
         TestGame game = new TestGame(map);
 
         // Create some units
-        final int soldierA = game.spawn(3, 5, RobotType.SOLDIER, Team.A);
+        final int soldierA = game.spawn(3, 5.01f, RobotType.SOLDIER, Team.A);
         final int soldierB = game.spawn(9, 5, RobotType.SOLDIER, Team.B);
         final int soldierB2 = game.spawn(10f,6.8f,RobotType.SOLDIER, Team.B);
         game.waitRounds(20);    // Wait for bots to mature to full health
@@ -574,7 +580,7 @@ public class RobotControllerTest {
         // Now check cases where it shouldn't hit soldierB
         game.round((id, rc) -> {
             if (id != soldierA) return;
-            rc.move(Direction.getNorth(),RobotType.SOLDIER.bodyRadius+0.01f);
+            rc.move(Direction.getNorth(),RobotType.SOLDIER.bodyRadius);
             rc.fireSingleShot(Direction.getEast()); // Shoot a bullet parallel, slightly above soldierB
         });
         game.waitRounds(5); // Bullet propagation
@@ -724,8 +730,6 @@ public class RobotControllerTest {
             // New robot should exist immediately
             RobotInfo[] nearbyRobots = rc.senseNearbyRobots();
             assertEquals(nearbyRobots.length,1);
-            // Can't move into its location
-            assertFalse(rc.canMove(nearbyRobots[0].getLocation()));
         });
         // Two robots should exist after it dies
         assertEquals(game.getWorld().getObjectInfo().getRobotCount(Team.A),2);


### PR DESCRIPTION
Unit changes:
* All: Stride radius cut in half
* Tanks: Body attack 2 -> 4, Bullet speed 3 -> 4, Attack power 4 -> 5
* Scout: HP 20 -> 10, Attack power 1 -> 0.5, Sight Radius 10 -> 12

Victory Point Changes:
* Victory point cost starts at 7.5, then increases by 12.5/3000 per round up to 20 at the end of a 3000 round match.
* Current victory point cost can be accessed with rc.getVictoryPointCost()
* Opponent victory points can now be sensed with rc.getOpponentVictoryPoints()

Misc:
* BROADCAST_MAX_CHANNELS increased from 1,000 to 10,000

Tests modified reflect changes in specs.