### PR TITLE
Avoid a NullPointerException in NetServer.onError

### DIFF
--- a/src/main/battlecode/server/NetServer.java
+++ b/src/main/battlecode/server/NetServer.java
@@ -162,6 +162,7 @@ public class NetServer extends WebSocketServer {
 
     @Override
     public void onError(WebSocket conn, Exception ex) {
-        System.err.println("Error from: "+conn.getRemoteSocketAddress()+": "+ex);
+        String addr = conn != null ? conn.getRemoteSocketAddress()+"" : "<unknown>";
+        System.err.println("Error from: "+addr+": "+ex);
     }
 }


### PR DESCRIPTION
I saw the following stack trace:
```
Exception in thread "WebsocketSelector14" java.lang.NullPointerException
        at battlecode.server.NetServer.onError(NetServer.java:165)
        at org.java_websocket.server.WebSocketServer.handleFatal(WebSocketServer.java:439)
        at org.java_websocket.server.WebSocketServer.run(WebSocketServer.java:287)
        at java.lang.Thread.run(Thread.java:745)
```

and indeed the first argument to `onError` can sometimes be null, so this seems like a reasonable fix.