### PR TITLE
Immediate bullet collision check

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -360,9 +360,25 @@ public strictfp class GameWorld {
     public int spawnBullet(int ID, Team team, float speed, float damage, MapLocation location, Direction direction, InternalRobot parent){
         InternalBullet bullet = new InternalBullet(
                 this, ID, team, speed, damage, location, direction);
-        objectInfo.spawnBullet(bullet, parent);
 
-        matchMaker.addSpawnedBullet(bullet);
+        matchMaker.addSpawnedBullet(bullet); // Even if the bullet will die this turn, make sure information about it is saved in the match file
+
+        // Check for collisions in the spot the bullet is being spawned
+        InternalRobot bot = this.objectInfo.getRobotAtLocation(location);
+        InternalTree tree = this.objectInfo.getTreeAtLocation(location);
+
+        if(bot != null) {
+            // If a there is a bot at this location, damage it.
+            bot.damageRobot(damage);
+            matchMaker.addDied(ID,true);
+        } else if (tree != null) {
+            // If a there is a tree at this location, damage it.
+            tree.damageTree(damage,team,false);
+            matchMaker.addDied(ID,true);
+        } else {
+            // Else, nothing else exists where the bullet was spawned. Go ahead and add it to spatial index.
+            objectInfo.spawnBullet(bullet, parent);
+        }
         return ID;
     }
 


### PR DESCRIPTION
Check for collisions as soon as a bullet is spawned by a unit. This means if two robots are <0.05 apart and one fires a bullet at the other, damage is done immediately (within the robot's turn). This resolves #431 because point-blank combat makes a bit more sense now. In the edge case that this happens to a scout/tree combo, the scout is hit by the bullet and not the tree.