### PR TITLE
Fix bytecode computations for arrays of length 0.

### DIFF
--- a/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
+++ b/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
@@ -587,6 +587,7 @@ public class InstrumentingMethodVisitor extends MethodNode implements Opcodes {
 	if (n.getOpcode() == ANEWARRAY) {
 	    InsnList newInsns = new InsnList();
 	    newInsns.add(new InsnNode(DUP));
+        newInsns.add(new MethodInsnNode(INVOKESTATIC, "battlecode/instrumenter/inject/RobotMonitor", "sanitizeArrayIndex", "(I)I"));
 	    newInsns.add(new MethodInsnNode(INVOKESTATIC, "battlecode/instrumenter/inject/RobotMonitor", "incrementBytecodesWithoutInterrupt", "(I)V"));
 	    instructions.insertBefore(n, newInsns);
 	} else {
@@ -604,6 +605,7 @@ public class InstrumentingMethodVisitor extends MethodNode implements Opcodes {
 	if (n.getOpcode() == NEWARRAY) {
 	    InsnList newInsns = new InsnList();
 	    newInsns.add(new InsnNode(DUP));
+        newInsns.add(new MethodInsnNode(INVOKESTATIC, "battlecode/instrumenter/inject/RobotMonitor", "sanitizeArrayIndex", "(I)I"));
 	    newInsns.add(new MethodInsnNode(INVOKESTATIC, "battlecode/instrumenter/inject/RobotMonitor", "incrementBytecodesWithoutInterrupt", "(I)V"));
 	    instructions.insertBefore(n, newInsns);
 	} else {

--- a/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
+++ b/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
@@ -549,6 +549,7 @@ public class InstrumentingMethodVisitor extends MethodNode implements Opcodes {
 	for (int i = 0; i < n.dims; i++) {
 	    newInsns.add(new InsnNode(DUP2_X1));
 	    newInsns.add(new InsnNode(IALOAD));
+        newInsns.add(new MethodInsnNode(INVOKESTATIC, "battlecode/instrumenter/inject/RobotMonitor", "sanitizeArrayIndex", "(I)I"));
 	    newInsns.add(new InsnNode(IMUL));
 	    newInsns.add(new InsnNode(DUP_X2));
 	    newInsns.add(new InsnNode(POP));

--- a/src/main/battlecode/instrumenter/inject/RobotMonitor.java
+++ b/src/main/battlecode/instrumenter/inject/RobotMonitor.java
@@ -149,6 +149,24 @@ public final class RobotMonitor {
     }
 
     /**
+     * When initializing an array, we need to pretend that all indices are at
+     * least 1, for the purposes of calculating bytecode cost. Because this
+     * calculation needs to be done in the instrumenter (and implemented in
+     * bytecode), the use of even simple helper methods like this dramatically
+     * simplifies the instrumenter code.
+     *
+     * THIS METHOD IS CALLED BY THE INSTRUMENTER.
+     *
+     * @param index the index to sanitize
+     *
+     * @return the sanitized array index.
+     */
+    @SuppressWarnings("unused")
+    public static int sanitizeArrayIndex(int index) {
+        return Math.max(1, index);
+    }
+
+    /**
      * Called when entering a debug_ method.
      *
      * THIS METHOD IS CALLED BY THE INSTRUMENTER.

--- a/src/main/battlecode/instrumenter/inject/RobotMonitor.java
+++ b/src/main/battlecode/instrumenter/inject/RobotMonitor.java
@@ -167,6 +167,30 @@ public final class RobotMonitor {
     }
 
     /**
+     * Calculates the bytecode cost of initializing a multidimensional array with the given
+     * dimensions. Note that the dimensions are passed in reverse order (so calling
+     * new int[1][2][3] passes this method the parameter {3, 2, 1}.
+     *
+     * THIS METHOD IS CALLED BY THE INSTRUMENTER.
+     *
+     * @param dims the dimensions of the multidimensional array, in reverse order
+     *
+     * @return the bytecode cost of instantiated the described array.
+     */
+    @SuppressWarnings("unused")
+    public static int calculateMultiArrayCost(int[] dims) {
+        int cost = 1;
+        for (int i = dims.length-1; i >= 0; i--) {
+            if (dims[i] == 0)
+                break;
+            cost *= dims[i];
+        }
+
+        System.out.println(cost);
+        return cost;
+    }
+
+    /**
      * Called when entering a debug_ method.
      *
      * THIS METHOD IS CALLED BY THE INSTRUMENTER.

--- a/src/test/battlecode/instrumenter/sample/testplayermultiarraybytecode/RobotPlayer.java
+++ b/src/test/battlecode/instrumenter/sample/testplayermultiarraybytecode/RobotPlayer.java
@@ -14,7 +14,7 @@ public class RobotPlayer {
 	int z = 4;
 	while (x <= 16) {
 	    Clock.yield();
-	    byte[][][] b = new byte[x][y][z];
+	    byte[][][][] b = new byte[x][y][z][0];
 	    Clock.yield();
 	    x *= 2;
 	    y *= 3;


### PR DESCRIPTION
Previously, a multidimensional array with a length 0 component was free to instantiate, regardless of the size of the other components. This can be abused by competitors and used as a free boolean array. This fixes this exploit by treating indices as max(1, index) for the purposes of bytecode computation (the resultant array will still have length 0 components).