### PR TITLE
Robots can't get stuck on top of each other

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -399,7 +399,21 @@ public strictfp class GameWorld {
             RobotType toSpawn = tree.getContainedRobot();
             float containedBullets = tree.getContainedBullets();
 
+            // Spawn a robot if there was one in the tree
             if (toSpawn != null && destroyedBy != Team.NEUTRAL && fromChop) {
+
+
+                //First, kill any scouts that would overlap with the new robot
+                InternalRobot[] overlappingBots = objectInfo.getAllRobotsWithinRadius(tree.getLocation(), toSpawn.bodyRadius);
+                for(InternalRobot bot : overlappingBots) {
+                    if(bot.getType() == RobotType.SCOUT) {
+                        this.destroyRobot(bot.getID());
+                    } else {
+                        throw new RuntimeException("The robot within the tree was overlapping with a non-scout robot");
+                    }
+                }
+
+                // Now spawn the new robot
                 this.spawnRobot(toSpawn, tree.getLocation(), destroyedBy);
             }
             if (containedBullets > 0 && fromChop) {


### PR DESCRIPTION
If a tree needs to spawn a robot when it dies, it kills any scouts that would overlap.

Resolves #437 