### PR TITLE
Replace Object.toString() with deterministic version

### DIFF
--- a/src/main/battlecode/instrumenter/TeamClassLoaderFactory.java
+++ b/src/main/battlecode/instrumenter/TeamClassLoaderFactory.java
@@ -80,7 +80,7 @@ public final class TeamClassLoaderFactory {
      * for every individual player.
      */
     protected final static Set<String> alwaysRedefine = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "battlecode.instrumenter.inject.ObjectHashCode",
+            "battlecode.instrumenter.inject.ObjectMethods",
             "battlecode.instrumenter.inject.InstrumentableFunctions",
             "battlecode.instrumenter.inject.System",
             "battlecode.instrumenter.inject.RobotMonitor",

--- a/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
+++ b/src/main/battlecode/instrumenter/bytecode/InstrumentingMethodVisitor.java
@@ -316,6 +316,7 @@ public class InstrumentingMethodVisitor extends MethodNode implements Opcodes {
                 // Make sure this is kept up to date with visitMethodInsnNode.
                 // @author James Gilles, in penance.
                 if ((h.getName().equals("hashCode") && h.getDesc().equals("()I") && n.getOpcode() != INVOKESTATIC)
+                        || (h.getName().equals("toString") && h.getDesc().equals("()Ljava/lang/String;") && n.getOpcode() != INVOKESTATIC)
                         || (h.getOwner().equals("java/util/Random") && h.getName().equals("<init>") && h.getDesc().equals("()V"))
                         || (h.getOwner().equals("java/lang/String") && ((h.getName().equals("<init>") && h.getDesc().equals("([B)V"))
                             || (h.getName().equals("<init>") && h.getDesc().equals("([BII)V"))
@@ -360,9 +361,19 @@ public class InstrumentingMethodVisitor extends MethodNode implements Opcodes {
             endOfBasicBlock(n);
             // replace hashCode with deterministic version
             // send the object, its hash code, and the hash code method owner to
-            // ObjectHashCode for analysis
-            n.owner = "battlecode/instrumenter/inject/ObjectHashCode";
+            // ObjectMethods for analysis
+            n.owner = "battlecode/instrumenter/inject/ObjectMethods";
             n.desc = "(Ljava/lang/Object;)I";
+            n.itf = false;
+            n.setOpcode(INVOKESTATIC);
+            return;
+        }
+
+        if (n.name.equals("toString") && n.desc.equals("()Ljava/lang/String;") && n.getOpcode() != INVOKESTATIC) {
+            bytecodeCtr++;
+            endOfBasicBlock(n);
+            n.owner = "battlecode/instrumenter/inject/ObjectMethods";
+            n.desc = "(Ljava/lang/Object;)Ljava/lang/String;";
             n.itf = false;
             n.setOpcode(INVOKESTATIC);
             return;

--- a/src/main/battlecode/instrumenter/inject/ObjectMethods.java
+++ b/src/main/battlecode/instrumenter/inject/ObjectMethods.java
@@ -6,18 +6,21 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 
 @SuppressWarnings("unused")
-public class ObjectHashCode {
+public class ObjectMethods {
 
     static final Method objectHashCode;
     static final Method enumHashCode;
     static final Method characterHashCode;
 
+    static final Method objectToString;
+
     static {
-        Method tmpo = null, tmpe = null, tmpc = null;
+        Method tmpo = null, tmpe = null, tmpc = null, tmps = null;
         try {
             tmpo = Object.class.getMethod("hashCode");
             tmpe = Enum.class.getMethod("hashCode");
             tmpc = Character.class.getMethod("hashCode");
+            tmps = Object.class.getMethod("toString");
         } catch (Exception e) {
             throw new RuntimeException("Can't load needed functions", e);
         }
@@ -25,6 +28,7 @@ public class ObjectHashCode {
         objectHashCode = tmpo;
         enumHashCode = tmpe;
         characterHashCode = tmpc;
+        objectToString = tmps;
     }
 
     static int lastHashCode = -1;
@@ -33,12 +37,20 @@ public class ObjectHashCode {
 
     // reflection is slow so cache the results
     static HashMap<Class, Boolean> usesOHC = new HashMap<>();
+    static HashMap<Class, Boolean> usesOTS = new HashMap<>();
 
     static public int hashCode(Object o) throws NoSuchMethodException {
         if (usesObjectHashCode(o.getClass()))
             return identityHashCode(o);
         else
             return o.hashCode();
+    }
+
+    static public String toString(Object o) throws NoSuchMethodException {
+        if (usesObjectToString(o.getClass()))
+            return identityToString(o);
+        else
+            return o.toString();
     }
 
     static private boolean usesObjectHashCode(Class<?> cl) throws NoSuchMethodException {
@@ -53,6 +65,16 @@ public class ObjectHashCode {
         return b;
     }
 
+    static private boolean usesObjectToString(Class<?> cl) throws NoSuchMethodException {
+        Boolean b = usesOTS.get(cl);
+        if (b == null) {
+            Method toStringMethod = cl.getMethod("toString");
+            b = toStringMethod.equals(objectToString);
+            usesOTS.put(cl, b);
+        }
+        return b;
+    }
+
     static public int identityHashCode(Object o) {
         Integer code = codes.get(o);
         if (code == null) {
@@ -62,7 +84,11 @@ public class ObjectHashCode {
             return code;
     }
 
-    private ObjectHashCode() {
+    static public String identityToString(Object o) {
+        return "object" + Integer.toString(identityHashCode(o));
+    }
+
+    private ObjectMethods() {
     }
 
 }

--- a/src/main/battlecode/instrumenter/inject/System.java
+++ b/src/main/battlecode/instrumenter/inject/System.java
@@ -130,7 +130,7 @@ public final class System {
     }
 
     public static int identityHashCode(Object x) {
-        return ObjectHashCode.identityHashCode(x);
+        return ObjectMethods.identityHashCode(x);
     }
 
     public static String getProperty(String key) {

--- a/src/test/battlecode/instrumenter/sample/instrumentertest/DoesntOverrideToString.java
+++ b/src/test/battlecode/instrumenter/sample/instrumentertest/DoesntOverrideToString.java
@@ -1,0 +1,8 @@
+package instrumentertest;
+
+@SuppressWarnings("unused")
+public class DoesntOverrideToString {
+    public String getToString() {
+        return this.toString();
+    }
+}

--- a/src/test/battlecode/instrumenter/sample/instrumentertest/OverridesToString.java
+++ b/src/test/battlecode/instrumenter/sample/instrumentertest/OverridesToString.java
@@ -1,0 +1,12 @@
+package instrumentertest;
+
+@SuppressWarnings("unused")
+public class OverridesToString {
+    public String getToString() {
+        return this.toString();
+    }
+    @Override
+    public String toString() {
+        return "foo";
+    }
+}


### PR DESCRIPTION
Object.toString() now returns a deterministic string derived from the same code used for Object.hashCode(), when the toString method is not redefined. This should still work for objects which use the default implementation of toString(), but not for hashCode(), and vice versa.