### PR TITLE
removed exception

### DIFF
--- a/src/main/battlecode/world/GameWorld.java
+++ b/src/main/battlecode/world/GameWorld.java
@@ -409,7 +409,8 @@ public strictfp class GameWorld {
                     if(bot.getType() == RobotType.SCOUT) {
                         this.destroyRobot(bot.getID());
                     } else {
-                        throw new RuntimeException("The robot within the tree was overlapping with a non-scout robot");
+                        // TODO: seems like we only hit this on floating point errors
+                        //throw new RuntimeException("The robot within the tree was overlapping with a non-scout robot");
                     }
                 }
 


### PR DESCRIPTION
On maps where a unit is adjacent to a tree when it is chopped down, this error was throwing because of floating point errors.