### PR TITLE
Remove an unnecessary printout

### DIFF
--- a/src/main/battlecode/instrumenter/inject/RobotMonitor.java
+++ b/src/main/battlecode/instrumenter/inject/RobotMonitor.java
@@ -186,7 +186,6 @@ public final class RobotMonitor {
             cost *= dims[i];
         }
 
-        System.out.println(cost);
         return cost;
     }
 


### PR DESCRIPTION
This printout caused teams to see a printout of the calculated cost of their array every time they created a multidimensional array, this is what caused the "6 bug" that the Water Buffalos were asking about in this forum thread: http://www.battlecodeforum.org/t/are-anybody-elses-robots-outputting-6-in-the-console-all-the-buggin-time/686